### PR TITLE
Add macroquad support

### DIFF
--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -72,18 +72,22 @@ impl AndroidBuildCommand {
         let build_targets = context.android_build_targets(&self.target);
         let mut compiled_libs = Vec::new();
         for build_target in build_targets.iter() {
-            let lib_name = format!("lib{}.so", package_name.replace("-", "_"));
+            let mut lib_name = format!("lib{}.so", package_name.replace("-", "_"));
             let rust_triple = build_target.rust_triple();
             config.status_message("Compiling for architecture", rust_triple)?;
             if self.shared.quad {
-                android::compile_macroquad_rust_for_android(
-                    target_sdk_version,
-                    ndk.ndk_path(),
-                    &context.package_manifest_path,
+                lib_name = android::compile_macroquad_rust_for_android(
+                    &ndk,
+                    target.clone(),
                     *build_target,
-                    // &project_path,
-                    // profile,
+                    &project_path,
+                    profile,
+                    self.shared.features.clone(),
+                    self.shared.all_features,
+                    self.shared.no_default_features,
+                    target_sdk_version,
                 )?;
+                println!("{}", lib_name);
             } else {
                 android::compile_rust_for_android(
                     &ndk,

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -72,11 +72,11 @@ impl AndroidBuildCommand {
         let build_targets = context.android_build_targets(&self.target);
         let mut compiled_libs = Vec::new();
         for build_target in build_targets.iter() {
-            let mut lib_name = format!("lib{}.so", package_name.replace("-", "_"));
+            let lib_name = format!("lib{}.so", package_name.replace("-", "_"));
             let rust_triple = build_target.rust_triple();
             config.status_message("Compiling for architecture", rust_triple)?;
             if self.shared.quad {
-                lib_name = android::compile_macroquad_rust_for_android(
+                android::compile_macroquad_rust_for_android(
                     &ndk,
                     *build_target,
                     &project_path,
@@ -85,8 +85,8 @@ impl AndroidBuildCommand {
                     self.shared.all_features,
                     self.shared.no_default_features,
                     target_sdk_version,
+                    &lib_name,
                 )?;
-                println!("{}", lib_name);
             } else {
                 android::compile_rust_for_android(
                     &ndk,

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -78,7 +78,6 @@ impl AndroidBuildCommand {
             if self.shared.quad {
                 lib_name = android::compile_macroquad_rust_for_android(
                     &ndk,
-                    target.clone(),
                     *build_target,
                     &project_path,
                     profile,

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -31,12 +31,10 @@ zip = "0.5.13"
 walkdir = "2.3.2"
 zip-extensions = "0.6"
 glob = "0.3.0"
+tempfile = "3.2"
 
 cargo = "0.57.0"
 cargo-util = "0.1.1"
-
-[dev-dependencies]
-tempfile = "3.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crossbundle/tools/src/error.rs
+++ b/crossbundle/tools/src/error.rs
@@ -36,6 +36,8 @@ pub enum AndroidError {
     InvalidBuildTarget(String),
     /// Failed to find AndroidManifest.xml in path: {0}
     FailedToFindAndroidManifest(String),
+    /// Unable to find NDK file
+    UnableToFindNDKFile,
     /// AndroidManifest error
     AndroidManifest(#[from] android_manifest::error::Error),
 }


### PR DESCRIPTION
This PR adds `--quad` option to build `macroquad` projects APK. This is done using the `cargo` crate with a compiler executor.