### PR TITLE
main-hello-world.md: information about --quad flag

### DIFF
--- a/docs/main-hello-world.md
+++ b/docs/main-hello-world.md
@@ -67,6 +67,8 @@ Let's build and run our first CrossBundle application.
 ```sh
 # cd project-name
 crossbundle run android
+# or (if your project uses macroquad)
+crossbundle run android --quad
 # or
 crossbundle run apple
 ```


### PR DESCRIPTION
I had to find myself that --quad flag is needed for macroquad project.
That is why I suggest added the information about the flag to main-hello-world.md.