### PR TITLE
Fix android manifest generation: package name and screen

### DIFF
--- a/crossbundle/cli/README.md
+++ b/crossbundle/cli/README.md
@@ -52,7 +52,7 @@ app_name = "Example"
 version_name = "0.1.0"
 # Internal version number used to determine whether one version is more recent than another
 # See https://developer.android.com/guide/topics/manifest/manifest-element
-version_code = "1"
+version_code = 1
 # Min SDK version
 min_sdk_version = 21
 # Target SDK version

--- a/crossbundle/cli/README.md
+++ b/crossbundle/cli/README.md
@@ -43,21 +43,71 @@ More information about how to set up the environment in the **Android setup** an
 
 ---
 
-## Syntax
+## Cargo.toml Metadata syntax
+
+```toml
+# The user-friendly application name for your app. Displayed in the applications menu
+app_name = "Example"
+# The version number shown to users
+version_name = "0.1.0"
+# Internal version number used to determine whether one version is more recent than another
+# See https://developer.android.com/guide/topics/manifest/manifest-element
+version_code = "1"
+# Min SDK version
+min_sdk_version = 21
+# Target SDK version
+target_sdk_version = 30
+# Max SDK version
+max_sdk_version = 31
+# Virtual path your application's icon as mipmap resource.
+icon = "ic_launcher"
+
+# Use Android.manifest file or generate from Cargo.toml
+use_android_manifest = true
+# Path to Android.manifest file
+android_manifest_path = "path/to/AndroidManifest.xml"
+
+# Use Info.plist file or generate from Cargo.toml
+use_info_plist = true
+# Path to Info.plist file
+info_plist_path = "path/to/Info.plist"
+
+# Android package name to place in AndroidManifest.xml.
+android_package_name = "com.example.Example"
+# Android resources directory path relatively to project path.
+android_res = "res/android"
+# Android assets directory path relatively to project path.
+android_assets = "assets"
+# Android build targets.
+android_build_targets = ["aarch64-linux-android"]
+
+# Apple build targets.
+apple_build_targets = ["aarch64-apple-ios", "x86_64-apple-ios"]
+# Apple resources directory path relatively to project path.
+apple_res = "res/apple"
+# Apple assets directory path relatively to project path.
+apple_assets = "assets"
+
+# Adds a uses-permission element to the AndroidManifest.xml.
+# Note that android_version 23 and higher, Android requires the application to request permissions at runtime.
+[[package.metadata.android_permissions]]
+name = "android.permission.INTERNET"
+max_sdk_version = 21
+```
+
+## CLI options and flags
 
 To see the complete documentation for each command/subcommand you can write `-h` or `--help`:
 
 ```sh
 crossbundle -h
 crossbundle build android -h
-crossbundle run android -h
+crossbundle run apple -h
+crossbundle install -h
+# ...
 ```
 
-### Command `crossbundle`
-
-```sh
-crossbundle <SUBCOMMAND> [FLAGS] [OPTIONS]
-```
+Result of `crossbundle -h`:
 
 ```text
 USAGE:
@@ -71,247 +121,14 @@ OPTIONS:
     -V, --version                      Print version information
 
 SUBCOMMANDS:
-    build    Starts the process of building/packaging/signing of the rust crate
-    help     Print this message or the help of the given subcommand(s)
-    log      Attach logger to device with running application
-    new      Creates a new Cargo package in the given directory. Project will be ready to build
-             with `crossbundle`
-    run      Executes `build` command and then deploy and launches the application on the
-             device/emulator
-```
-
-### Command `crossbundle build android`
-
-```sh
-crossbundle build android [FLAGS] [OPTIONS]
-```
-
-```text
-USAGE:
-    crossbundle build android [OPTIONS]
-
-OPTIONS:
-        --aab
-            Generating aab. By default crossbow generating apk
-
-        --all-features
-            Activate all available features of selected package
-
-        --example <EXAMPLE>
-            Build the specified example
-
-        --features <FEATURES>...
-            Space or comma separated list of features to activate. These features only apply to the
-            current directory's package. Features of direct dependencies may be enabled with `<dep-
-            name>/<feature-name>` syntax. This flag may be specified multiple times, which enables
-            all specified features
-
-    -h, --help
-            Print help information
-
-        --no-default-features
-            Do not activate the `default` feature of the current directory's package
-
-        --quad
-            Specifies to build macroquad game engine
-
-        --release
-            Build optimized artifact with the `release` profile
-
-        --sign-key-alias <SIGN_KEY_ALIAS>
-            Signing key alias
-
-        --sign-key-pass <SIGN_KEY_PASS>
-            Signing key password
-
-        --sign-key-path <SIGN_KEY_PATH>
-            Path to the signing key
-
-        --target <TARGET>...
-            Build for the given android architecture. Supported targets are: `armv7-linux-
-            androideabi`, `aarch64-linux-android`, `i686-linux-android`, `x86_64-linux-android`
-            [default: aarch64-linux-android]
-
-        --target-dir <TARGET_DIR>
-            Directory for generated artifact and intermediate files
-```
-
-### Command `crossbundle build apple`
-
-```sh
-crossbundle build apple [FLAGS] [OPTIONS]
-```
-
-```text
-USAGE:
-    crossbundle build apple [OPTIONS]
-
-OPTIONS:
-        --all-features
-            Activate all available features of selected package
-
-        --bin <BIN>
-            Specify custom cargo binary
-
-        --example <EXAMPLE>
-            Build the specified example
-
-        --features <FEATURES>...
-            Space or comma separated list of features to activate. These features only apply to the
-            current directory's package. Features of direct dependencies may be enabled with `<dep-
-            name>/<feature-name>` syntax. This flag may be specified multiple times, which enables
-            all specified features
-
-    -h, --help
-            Print help information
-
-        --identity <IDENTITY>
-            The id of the identity used for signing. It won't start the signing process until you
-            provide this flag
-
-        --no-default-features
-            Do not activate the `default` feature of the current directory's package
-
-        --profile-name <PROFILE_NAME>
-            Provisioning profile name to find in this directory:
-            `~/Library/MobileDevice/Provisioning\ Profiles/`
-
-        --profile-path <PROFILE_PATH>
-            Absolute path to provisioning profile
-
-        --quad
-            Specifies to build macroquad game engine
-
-        --release
-            Build optimized artifact with the `release` profile
-
-        --target <TARGET>...
-            Build for the given apple architecture. Supported targets are: 'aarch64-apple-ios`,
-            `armv7-apple-ios`, `armv7s-apple-ios`, `i386-apple-ios`, `x86_64-apple-ios` [default:
-            aarch64-apple-ios]
-
-        --target-dir <TARGET_DIR>
-            Directory for generated artifact and intermediate files
-
-        --team-identifier <TEAM_IDENTIFIER>
-            The team identifier of your signing identity
-```
-
-### Command `crossbundle run android`
-
-```sh
-crossbundle build android [FLAGS] [OPTIONS]
-```
-
-```sh
-USAGE:
-    crossbundle run android [OPTIONS]
-
-OPTIONS:
-        --aab
-            Generating aab. By default crossbow generating apk
-
-        --all-features
-            Activate all available features of selected package
-
-        --example <EXAMPLE>
-            Build the specified example
-
-        --features <FEATURES>...
-            Space or comma separated list of features to activate. These features only apply to the
-            current directory's package. Features of direct dependencies may be enabled with `<dep-
-            name>/<feature-name>` syntax. This flag may be specified multiple times, which enables
-            all specified features
-
-    -h, --help
-            Print help information
-
-        --no-default-features
-            Do not activate the `default` feature of the current directory's package
-
-        --quad
-            Specifies to build macroquad game engine
-
-        --release
-            Build optimized artifact with the `release` profile
-
-        --sign-key-alias <SIGN_KEY_ALIAS>
-            Signing key alias
-
-        --sign-key-pass <SIGN_KEY_PASS>
-            Signing key password
-
-        --sign-key-path <SIGN_KEY_PATH>
-            Path to the signing key
-
-        --target <TARGET>...
-            Build for the given android architecture. Supported targets are: `armv7-linux-
-            androideabi`, `aarch64-linux-android`, `i686-linux-android`, `x86_64-linux-android`
-            [default: aarch64-linux-android]
-
-        --target-dir <TARGET_DIR>
-            Directory for generated artifact and intermediate files
-```
-
-### Command `crossbundle run apple`
-
-```sh
-crossbundle build apple [FLAGS] [OPTIONS]
-```
-
-```sh
-USAGE:
-    crossbundle build apple [OPTIONS]
-
-OPTIONS:
-        --all-features
-            Activate all available features of selected package
-
-        --bin <BIN>
-            Specify custom cargo binary
-
-        --example <EXAMPLE>
-            Build the specified example
-
-        --features <FEATURES>...
-            Space or comma separated list of features to activate. These features only apply to the
-            current directory's package. Features of direct dependencies may be enabled with `<dep-
-            name>/<feature-name>` syntax. This flag may be specified multiple times, which enables
-            all specified features
-
-    -h, --help
-            Print help information
-
-        --identity <IDENTITY>
-            The id of the identity used for signing. It won't start the signing process until you
-            provide this flag
-
-        --no-default-features
-            Do not activate the `default` feature of the current directory's package
-
-        --profile-name <PROFILE_NAME>
-            Provisioning profile name to find in this directory:
-            `~/Library/MobileDevice/Provisioning\ Profiles/`
-
-        --profile-path <PROFILE_PATH>
-            Absolute path to provisioning profile
-
-        --quad
-            Specifies to build macroquad game engine
-
-        --release
-            Build optimized artifact with the `release` profile
-
-        --target <TARGET>...
-            Build for the given apple architecture. Supported targets are: 'aarch64-apple-ios`,
-            `armv7-apple-ios`, `armv7s-apple-ios`, `i386-apple-ios`, `x86_64-apple-ios` [default:
-            aarch64-apple-ios]
-
-        --target-dir <TARGET_DIR>
-            Directory for generated artifact and intermediate files
-
-        --team-identifier <TEAM_IDENTIFIER>
-            The team identifier of your signing identity
+    build      Starts the process of building/packaging/signing of the rust crate
+    help       Print this message or the help of the given subcommand(s)
+    install    Installs bundletool and Android Studio's sdkmanager
+    log        Attach logger to device with running application
+    new        Creates a new Cargo package in the given directory. Project will be ready to
+               build with `crossbundle`
+    run        Executes `build` command and then deploy and launches the application on the
+               device/emulator
 ```
 
 ## Troubleshooting

--- a/crossbundle/cli/src/cargo_manifest.rs
+++ b/crossbundle/cli/src/cargo_manifest.rs
@@ -9,7 +9,7 @@ pub type CargoManifest = cargo_toml::Manifest<Metadata>;
 pub struct Metadata {
     pub app_name: Option<String>,
     pub version_name: Option<String>,
-    pub version_code: Option<String>,
+    pub version_code: Option<u32>,
     pub min_sdk_version: Option<u32>,
     pub target_sdk_version: Option<u32>,
     pub max_sdk_version: Option<u32>,

--- a/crossbundle/cli/src/cargo_manifest.rs
+++ b/crossbundle/cli/src/cargo_manifest.rs
@@ -16,9 +16,6 @@ pub struct Metadata {
     pub icon: Option<String>,
 
     #[serde(default)]
-    pub android_permissions: Vec<UsesPermission>,
-
-    #[serde(default)]
     pub use_android_manifest: bool,
     pub android_manifest_path: Option<PathBuf>,
 
@@ -41,4 +38,8 @@ pub struct Metadata {
     pub apple_res: Option<PathBuf>,
     /// Apple assets directory path relatively to project path.
     pub apple_assets: Option<PathBuf>,
+
+    /// TODO: Add android android_uses_features.
+    #[serde(default)]
+    pub android_permissions: Vec<UsesPermission>,
 }

--- a/crossbundle/cli/src/cargo_manifest.rs
+++ b/crossbundle/cli/src/cargo_manifest.rs
@@ -26,7 +26,8 @@ pub struct Metadata {
     pub use_info_plist: bool,
     pub info_plist_path: Option<PathBuf>,
 
-    pub android_app_id: Option<String>,
+    /// Android package name to place in AndroidManifest.xml.
+    pub android_package_name: Option<String>,
     /// Android resources directory path relatively to project path.
     pub android_res: Option<PathBuf>,
     /// Android assets directory path relatively to project path.

--- a/crossbundle/cli/src/commands/build/build_context.rs
+++ b/crossbundle/cli/src/commands/build/build_context.rs
@@ -43,6 +43,11 @@ impl BuildContext {
     }
 
     pub fn package_name(&self) -> String {
+        if let Some(metadata) = &self.cargo_package.metadata {
+            if let Some(package_name) = metadata.android_package_name.clone() {
+                return package_name;
+            };
+        };
         self.cargo_package.name.clone()
     }
 
@@ -109,7 +114,7 @@ impl BuildContext {
                 Ok(android::read_android_manifest(&path)?)
             } else {
                 let mut manifest = android::gen_minimal_android_manifest(
-                    metadata.android_app_id.clone(),
+                    metadata.android_package_name.clone(),
                     package_name,
                     metadata.app_name.clone(),
                     metadata

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -17,7 +17,7 @@ dunce = "1.0"
 fs_extra = "1.2"
 dirs = "4.0.0"
 simctl = { version = "0.1.1", package = "creator-simctl" }
-android-manifest = "0.1.3"
+android-manifest = "0.1.5"
 apple-bundle = "0.1.1"
 android-tools = "0.2.7"
 thiserror = "1.0"

--- a/crossbundle/tools/src/commands/android/gen_manifest.rs
+++ b/crossbundle/tools/src/commands/android/gen_manifest.rs
@@ -41,6 +41,7 @@ pub fn gen_minimal_android_manifest(
             )),
             activity: vec![Activity {
                 name: "android.app.NativeActivity".to_string(),
+                resizeable_activity: Some(true),
                 label: Some(StringResourceOrString::string(
                     app_name.as_ref().unwrap_or(&package_name.to_owned()),
                 )),

--- a/crossbundle/tools/src/commands/android/gen_manifest.rs
+++ b/crossbundle/tools/src/commands/android/gen_manifest.rs
@@ -7,7 +7,7 @@ pub fn gen_minimal_android_manifest(
     package_name: &str,
     app_name: Option<String>,
     version_name: String,
-    version_code: Option<String>,
+    version_code: Option<u32>,
     min_sdk_version: Option<u32>,
     target_sdk_version: u32,
     max_sdk_version: Option<u32>,

--- a/crossbundle/tools/tests/aapt2.rs
+++ b/crossbundle/tools/tests/aapt2.rs
@@ -67,7 +67,7 @@ fn test_aapt2_link() {
         "example",
         None,
         "0.0.1".to_string(),
-        Some("1".to_string()),
+        Some(1),
         Some(9),
         30,
         None,

--- a/examples/bevy-2d/Cargo.toml
+++ b/examples/bevy-2d/Cargo.toml
@@ -12,7 +12,7 @@ bevy = { version = "0.6.0", features = ["mp3"] }
 
 [package.metadata]
 app_name = "Bevy 2D"
-version_code = "1"
+version_code = 1
 target_sdk_version = 30
 icon = "ic_launcher"
 

--- a/examples/bevy-2d/Cargo.toml
+++ b/examples/bevy-2d/Cargo.toml
@@ -16,6 +16,7 @@ version_code = "1"
 target_sdk_version = 30
 icon = "ic_launcher"
 
+android_package_name = "com.example.bevy_2d"
 android_build_targets = ["aarch64-linux-android"]
 android_assets = "assets"
 android_res = "res/android"

--- a/examples/bevy-3d/Cargo.toml
+++ b/examples/bevy-3d/Cargo.toml
@@ -13,7 +13,7 @@ bevy = { version = "0.6.0" }
 [package.metadata]
 app_name = "Bevy 3D"
 target_sdk_version = 30
-version_code = "1"
+version_code = 1
 icon = "ic_launcher"
 
 android_build_targets = ["aarch64-linux-android", "armv7-linux-androideabi", "i686-linux-android", "x86_64-linux-android"]

--- a/examples/macroquad-3d/Cargo.toml
+++ b/examples/macroquad-3d/Cargo.toml
@@ -13,7 +13,7 @@ macroquad = "0.3"
 [package.metadata]
 app_name = "Macroquad 3D"
 target_sdk_version = 30
-version_code = "1"
+version_code = 1
 icon = "ic_launcher"
 
 use_android_manifest = true

--- a/examples/macroquad-3d/res/AndroidManifest.xml
+++ b/examples/macroquad-3d/res/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <activity
                 android:name="android.app.NativeActivity"
                 android:label="Macroquad 3D"
+                android:resizeableActivity="true"
                 android:configChanges="orientation|keyboardHidden|screenSize"  >
             <meta-data android:name="android.app.lib_name" android:value="macroquad_3d" />
             <intent-filter>


### PR DESCRIPTION
- [x] Make `resizeableActivity="true"` in minimal AndroidManifest generator.
- [x] Rename `android_app_id` to `android_package_name`.
- [x] Write documentation for `crossbundle` metadata inside `Cargo.toml`.
- [x] Change `version_code` from string to u32.

Closes #71, closes #76.
