### PR TITLE
Update bevy explorer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,5 @@ jobs:
       - name: Run all tests
         run: |
           export BUNDLETOOL_PATH="$HOME/bundletool.jar"
+          cargo update -p jsonrpsee-utils --precise 0.2.0-alpha.3
           cargo test --all

--- a/docs/install-linux-android.md
+++ b/docs/install-linux-android.md
@@ -12,7 +12,7 @@
 
 ## Add environment variables
 
-We need to make sure that Android-related environment variables are set in `PATH`, `ANDROID_SDK_ROOT`, and `ANDROID_NDK_ROOT`.
+We need to make sure that Android-related environment variables are set in `PATH`, `ANDROID_SDK_ROOT`|| `ANDROID_SDK_PATH` || `ANDROID_HOME`, and `ANDROID_NDK_ROOT`.
 
 For that edit **~/.bash_profile** or **~/.bashrc** files so they contain those lines:
 

--- a/docs/install-macos-android.md
+++ b/docs/install-macos-android.md
@@ -18,13 +18,13 @@ brew install --cask adoptopenjdk8
 
 ## Add environment variables
 
-We need to make sure that Android-related environment variables are set in `PATH`, `ANDROID_SDK_ROOT`, and `ANDROID_NDK_ROOT`.
+We need to make sure that Android-related environment variables are set in `PATH`, `ANDROID_SDK_ROOT`|| `ANDROID_SDK_PATH` || `ANDROID_HOME`, and `ANDROID_NDK_ROOT`.
 
 For that edit **~/.bash_profile**/**~/.bashrc** or **~/.zshrc** files so they contain those lines:
 
 ```sh
 export ANDROID_SDK_ROOT=$HOME/android/sdk
-export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/22.0.7026061
+export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/23.1.7779620
 ```
 
 If u will build application with emulator u should add this environment variables:

--- a/docs/install-windows-android.md
+++ b/docs/install-windows-android.md
@@ -15,7 +15,7 @@
 Take these steps to add Android-related environment variables:
 
 - From the Start search bar, enter ‘env’ and select **Edit environment variables for your account**.
-- Add `ANDROID_NDK_ROOT` variable with value `<path_to_sdk>\sdk\ndk\<version>`.<br/>(ex. `C:\Users\username\AppData\Local\Android\Sdk\ndk\22.1.7171670`)
+- Add `ANDROID_SDK_ROOT`|| `ANDROID_SDK_PATH` || `ANDROID_HOME` variable with value `<path_to_sdk>\sdk\ndk\<version>`.<br/>(ex. `C:\Users\username\AppData\Local\Android\Sdk\ndk\23.1.7779620`)
 - Add `ANDROID_SDK_ROOT` variable with value `<path_to_sdk>\sdk`.<br/>(ex. `C:\Users\username\AppData\Local\android\sdk`)
 
 If u will build application with emulator u should add this environment variables:
@@ -23,7 +23,7 @@ If u will build application with emulator u should add this environment variable
 - Add `<path_to_sdk>\sdk\tools\bin` to `PATH` variable.
 - Add `<path_to_sdk>\sdk\emulator` to `PATH` variable.
 
-Also, we need to make sure we have a java runtime environment (JRE) installed. We need a key tool utility from there. <br/>
+Also, we need to make sure we have a [java runtime environment](https://www.oracle.com/java/technologies/downloads/) (JRE) installed. We need a key tool utility from there. <br/>
 To make sure it's present type this command: `keytool -h`
 
 - If command above fails, add `<path_to_jre>\bin` to `PATH` environment variable.<br/>(ex. `C:\Program Files\Android\Android Studio\jre\bin`)

--- a/docs/main-hello-world.md
+++ b/docs/main-hello-world.md
@@ -31,9 +31,6 @@ version = "0.1.0"
 authors = ["Example <example@example.com>"]
 edition = "2021"
 
-[lib]
-crate-type = ["lib", "cdylib"]
-
 [dependencies]
 crossbundle = "*"
 
@@ -44,19 +41,10 @@ apple_res = "res/apple"
 ```
 
 ```rust
-// lib.rs
-
-#[crossbow::crossbundle_main]
-pub fn main() {
-    println!("Hello, project-name!");
-}
-```
-
-```rust
 // main.rs
 
 fn main() {
-    project_name::main();
+    println!("Hello, project-name!");
 }
 ```
 

--- a/docs/main-project-configuration.md
+++ b/docs/main-project-configuration.md
@@ -16,9 +16,6 @@ edition = "2021"
 [dependencies]
 crossbow = "0.1.0"
 
-[lib]
-crate-type = ["lib", "cdylib"]
-
 [package.metadata]
 app_name = "Creator 3D"
 target_sdk_version = 30

--- a/docs/using-subxt-with-bevy.md
+++ b/docs/using-subxt-with-bevy.md
@@ -12,11 +12,34 @@ bevy = "0.6.0"
 
 ## Bevy explorer example
 
-To learn how to use subxt with bevy engine, you can go to the examples/bevy-explorer.
+To learn how to use subxt with bevy engine, you can go to the examples/bevy-explorer or install bevy explorer template. Follow next steps:
 
-## Installing on the device
+1. Install cargo-generate:
 
-You can deploy the application on your device with commands below:
+```sh
+cargo install cargo-generate
+```
+
+2. Install bevy-explorer template:
+
+```sh
+crossbundle new example --template=bevy-explorer
+```
+
+3. After previous steps, now you can install the application on the device.
+
+## Installing application on the device
+
+You can deploy the application on your device with commands below. At first, you should go to example directory. Use it:
+
+Bash:
+
+```sh
+# If the template was installed
+cd example
+# If bevy-explorer example will be used
+cd example/bevy-explorer
+```
 
 To build APK and run it on the device using the command. If you want to build an application replaces `run` with `build`.
 

--- a/docs/using-subxt-with-bevy.md
+++ b/docs/using-subxt-with-bevy.md
@@ -1,0 +1,43 @@
+# Using subxt with bevy engine
+
+1. You need to install crossbundle if you haven't already. See [documention](https://github.com/dodorare/crossbow/tree/main/docs) to install it and configure your project.
+
+2. Specify substrate-subxt and bevy in your Cargo.toml. We prefer to use versions below:
+
+```sh
+[dependencies]
+substrate-subxt = "0.15"
+bevy = "0.6.0"
+```
+
+## Bevy explorer example
+
+To learn how to use subxt with bevy engine, you can go to the examples/bevy-explorer.
+
+## Installing on the device
+
+You can deploy the application on your device with commands below:
+
+To build APK and run it on the device using the command. If you want to build an application replaces `run` with `build`.
+
+```sh
+crossbundle run android
+# or
+crossbundle run apple
+```
+
+To build AAB and run it on the device using the command. If you want to build an application replaces `run` with `build`.
+
+```sh
+crossbundle run android --aab
+# or
+crossbundle run apple --aab
+```
+
+## Known issues
+
+You can face the problem with jsonrpsee-utils library used in subxt. One of the solutions is to downgrade the version. Use the command below:
+
+```sh
+cargo update -p jsonrpsee-utils --precise 0.2.0-alpha.3
+```

--- a/examples/bevy-explorer/Cargo.toml
+++ b/examples/bevy-explorer/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 crossbow = { version = "0.1.0", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
-# substrate-subxt = { git = "https://github.com/paritytech/substrate-subxt", rev = "08a3e6574d38ed7908e163ac554b81b59e0b8a67" }
 substrate-subxt = "0.14"
 tokio = { version = "1.2", features = ["sync", "macros"] }
 bevy = { version = "0.6.0", features = ["mp3"] }

--- a/examples/bevy-explorer/Cargo.toml
+++ b/examples/bevy-explorer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crossbow = { version = "0.1.0", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
-substrate-subxt = "0.14"
+substrate-subxt = "0.15"
 tokio = { version = "1.2", features = ["sync", "macros"] }
 bevy = { version = "0.6.0", features = ["mp3"] }
 

--- a/examples/bevy-explorer/src/explorer.rs
+++ b/examples/bevy-explorer/src/explorer.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 #[cfg(not(target_os = "android"))]
 pub const TEXT_FONT_SIZE: f32 = 30.0;
 #[cfg(target_os = "android")]
-pub const TEXT_FONT_SIZE: f32 = 90.0;
+pub const TEXT_FONT_SIZE: f32 = 30.0;
 
 pub struct ExplorerStateChannel {
     pub tx: mpsc::Sender<ExplorerState>,


### PR DESCRIPTION
Fix crossbundle installation with new version code type. Bump substrate-subxt version from 0.14 to 0.15. Was fixed problem with jsonrpsee-utils library, see using-subxt-with-bevy.md document. 