### PR TITLE
Replace cargo_toml library with cargo inner TomlManifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,13 @@ jobs:
           toolchain: stable
           override: true
       - name: Install Apple targets
-        run: rustup target add aarch64-apple-ios x86_64-apple-ios
+        run: |
+        rustup upgrade
+        rustup target add aarch64-apple-ios x86_64-apple-ios
       - name: Install Android targets
-        run: rustup target add aarch64-linux-android x86_64-linux-android
+        run: |
+        rustup upgrade
+        rustup target add aarch64-linux-android x86_64-linux-android
       - name: Install bundletool
         run: |
           wget https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,12 @@ jobs:
           override: true
       - name: Install Apple targets
         run: |
-        rustup upgrade
-        rustup target add aarch64-apple-ios x86_64-apple-ios
+          rustup upgrade
+          rustup target add aarch64-apple-ios x86_64-apple-ios
       - name: Install Android targets
         run: |
-        rustup upgrade
-        rustup target add aarch64-linux-android x86_64-linux-android
+          rustup upgrade
+          rustup target add aarch64-linux-android x86_64-linux-android
       - name: Install bundletool
         run: |
           wget https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ndk-glue = "0.6.0"
 [patch.crates-io]
 ron = { git = "https://github.com/enfipy/ron", rev = "3b1f28075071d743469347575b34caf2043beeb9" }
 winit = { git = "https://github.com/rust-windowing/winit", rev = "f93f2c158bf527ed56ab2b6f5272214f0c1d9f7d" }
-bevy = { git = "https://github.com/enfipy/bevy", rev = "bf72b6f620ca12a603d26a7cda37b1b17227bf41" }
+bevy = { git = "https://github.com/Heezay/bevy", rev = "f368754c8d7cc8e8fbc6c913c44450d30388276e" }
 
 [features]
 default = []

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -36,6 +36,8 @@ fs_extra = "1.2"
 android-tools = "0.2.7"
 dirs = "4.0.0"
 ureq = "2.4.0"
+cargo = "0.59.0"
+cargo-util = "0.1.1"
 
 [features]
 default = ["android", "ios"]

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -24,7 +24,6 @@ path = "src/main.rs"
 [dependencies]
 crossbundle-tools = { path = "../tools", version = "0.1.3" }
 clap = { version = "3.0.5", features = ["derive"] }
-cargo_toml = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
 dunce = "1.0"
 thiserror = "1.0"

--- a/crossbundle/cli/src/cargo_manifest.rs
+++ b/crossbundle/cli/src/cargo_manifest.rs
@@ -1,4 +1,3 @@
-pub use cargo_toml::Package as CargoPackage;
 use crossbundle_tools::types::{android_manifest::UsesPermission, *};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/crossbundle/cli/src/cargo_manifest.rs
+++ b/crossbundle/cli/src/cargo_manifest.rs
@@ -3,8 +3,6 @@ use crossbundle_tools::types::{android_manifest::UsesPermission, *};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub type CargoManifest = cargo_toml::Manifest<Metadata>;
-
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Metadata {
     pub app_name: Option<String>,

--- a/crossbundle/cli/src/commands/build/build_context.rs
+++ b/crossbundle/cli/src/commands/build/build_context.rs
@@ -1,8 +1,9 @@
 use crate::{cargo_manifest::Metadata, error::Result};
-use cargo::core::{Manifest, SourceId};
+use cargo::core::Manifest;
 use crossbundle_tools::{
     commands::{
         android, apple, find_package_cargo_manifest_path, find_workspace_cargo_manifest_path,
+        parse_manifest,
     },
     tools::AndroidSdk,
     types::{
@@ -30,16 +31,7 @@ impl BuildContext {
         let target_dir =
             target_dir.unwrap_or_else(|| workspace_manifest_path.parent().unwrap().join("target"));
         info!("Parsing Cargo.toml");
-        let source_id = SourceId::for_path(&package_manifest_path).unwrap();
-        let config = cargo::util::config::Config::default().unwrap();
-        let either_manifest =
-            cargo::util::toml::read_manifest(&package_manifest_path, source_id, &config)
-                .unwrap()
-                .0;
-        let manifest = match either_manifest {
-            cargo::core::EitherManifest::Real(manifest) => manifest,
-            cargo::core::EitherManifest::Virtual(..) => todo!(),
-        };
+        let manifest = parse_manifest(&package_manifest_path)?;
         let custom_metadata = manifest.custom_metadata().unwrap().to_owned();
         let metadata = custom_metadata.try_into::<Metadata>().unwrap();
         Ok(Self {

--- a/crossbundle/cli/src/commands/build/build_context.rs
+++ b/crossbundle/cli/src/commands/build/build_context.rs
@@ -1,7 +1,5 @@
-use crate::{
-    cargo_manifest::{CargoManifest, CargoPackage, Metadata},
-    error::{Error, Result},
-};
+use crate::{cargo_manifest::Metadata, error::Result};
+use cargo::core::{Manifest, SourceId};
 use crossbundle_tools::{
     commands::{
         android, apple, find_package_cargo_manifest_path, find_workspace_cargo_manifest_path,
@@ -19,7 +17,8 @@ pub struct BuildContext {
     pub workspace_manifest_path: PathBuf,
     pub package_manifest_path: PathBuf,
     pub project_path: PathBuf,
-    pub cargo_package: CargoPackage<Metadata>,
+    pub manifest: Manifest,
+    pub metadata: Metadata,
     pub target_dir: PathBuf,
 }
 
@@ -31,35 +30,42 @@ impl BuildContext {
         let target_dir =
             target_dir.unwrap_or_else(|| workspace_manifest_path.parent().unwrap().join("target"));
         info!("Parsing Cargo.toml");
-        let cargo_manifest = CargoManifest::from_path_with_metadata(&package_manifest_path)?;
-        let cargo_package = cargo_manifest.package.ok_or(Error::InvalidManifest)?;
+        let source_id = SourceId::for_path(&package_manifest_path).unwrap();
+        let config = cargo::util::config::Config::default().unwrap();
+        let either_manifest =
+            cargo::util::toml::read_manifest(&package_manifest_path, source_id, &config)
+                .unwrap()
+                .0;
+        let manifest = match either_manifest {
+            cargo::core::EitherManifest::Real(manifest) => manifest,
+            cargo::core::EitherManifest::Virtual(..) => todo!(),
+        };
+        let custom_metadata = manifest.custom_metadata().unwrap().to_owned();
+        let metadata = custom_metadata.try_into::<Metadata>().unwrap();
         Ok(Self {
             workspace_manifest_path,
             package_manifest_path,
+            manifest,
             project_path,
-            cargo_package,
+            metadata,
             target_dir,
         })
     }
 
     pub fn package_name(&self) -> String {
-        if let Some(metadata) = &self.cargo_package.metadata {
-            if let Some(package_name) = metadata.android_package_name.clone() {
-                return package_name;
-            };
+        if let Some(package_name) = self.metadata.android_package_name.clone() {
+            return package_name;
         };
-        self.cargo_package.name.clone()
+        self.manifest.summary().name().to_string()
     }
 
     pub fn package_version(&self) -> String {
-        self.cargo_package.version.clone()
+        self.manifest.summary().version().to_string()
     }
 
     pub fn target_sdk_version(&self, sdk: &AndroidSdk) -> u32 {
-        if let Some(metadata) = &self.cargo_package.metadata {
-            if let Some(target_sdk_version) = metadata.target_sdk_version {
-                return target_sdk_version;
-            };
+        if let Some(target_sdk_version) = self.metadata.target_sdk_version {
+            return target_sdk_version;
         };
         sdk.default_platform()
     }
@@ -68,15 +74,10 @@ impl BuildContext {
         if !build_targets.is_empty() {
             return build_targets.clone();
         };
-        if self.cargo_package.metadata.is_none() {
+        if self.metadata.android_build_targets.is_none() {
             return vec![AndroidTarget::Aarch64LinuxAndroid];
         };
-        let targets = self
-            .cargo_package
-            .metadata
-            .clone()
-            .unwrap()
-            .android_build_targets;
+        let targets = self.metadata.android_build_targets.clone();
         if targets.is_some() && !targets.as_ref().unwrap().is_empty() {
             return targets.unwrap();
         };
@@ -84,19 +85,11 @@ impl BuildContext {
     }
 
     pub fn android_res(&self) -> Option<PathBuf> {
-        self.cargo_package
-            .metadata
-            .as_ref()
-            .map(|m| m.android_res.clone())
-            .unwrap_or_default()
+        self.metadata.android_res.clone()
     }
 
     pub fn android_assets(&self) -> Option<PathBuf> {
-        self.cargo_package
-            .metadata
-            .as_ref()
-            .map(|m| m.android_assets.clone())
-            .unwrap_or_default()
+        self.metadata.android_assets.clone()
     }
 
     pub fn gen_android_manifest(
@@ -105,36 +98,35 @@ impl BuildContext {
         package_name: &String,
         debuggable: bool,
     ) -> Result<AndroidManifest> {
-        if let Some(metadata) = &self.cargo_package.metadata {
-            if metadata.use_android_manifest {
-                let path = metadata
-                    .android_manifest_path
+        if self.metadata.use_android_manifest {
+            let path = self
+                .metadata
+                .android_manifest_path
+                .clone()
+                .unwrap_or_else(|| self.project_path.join("AndroidManifest.xml"));
+            Ok(android::read_android_manifest(&path)?)
+        } else if !self.metadata.use_android_manifest {
+            let mut manifest = android::gen_minimal_android_manifest(
+                self.metadata.android_package_name.clone(),
+                package_name,
+                self.metadata.app_name.clone(),
+                self.metadata
+                    .version_name
                     .clone()
-                    .unwrap_or_else(|| self.project_path.join("AndroidManifest.xml"));
-                Ok(android::read_android_manifest(&path)?)
-            } else {
-                let mut manifest = android::gen_minimal_android_manifest(
-                    metadata.android_package_name.clone(),
-                    package_name,
-                    metadata.app_name.clone(),
-                    metadata
-                        .version_name
-                        .clone()
-                        .unwrap_or(self.package_version()),
-                    metadata.version_code.clone(),
-                    metadata.min_sdk_version,
-                    metadata
-                        .target_sdk_version
-                        .unwrap_or_else(|| sdk.default_platform()),
-                    metadata.max_sdk_version,
-                    metadata.icon.clone(),
-                    debuggable,
-                );
-                if !metadata.android_permissions.is_empty() {
-                    manifest.uses_permission = metadata.android_permissions.clone();
-                }
-                Ok(manifest)
+                    .unwrap_or(self.package_version()),
+                self.metadata.version_code.clone(),
+                self.metadata.min_sdk_version,
+                self.metadata
+                    .target_sdk_version
+                    .unwrap_or_else(|| sdk.default_platform()),
+                self.metadata.max_sdk_version,
+                self.metadata.icon.clone(),
+                debuggable,
+            );
+            if !self.metadata.android_permissions.is_empty() {
+                manifest.uses_permission = self.metadata.android_permissions.clone();
             }
+            Ok(manifest)
         } else {
             let target_sdk_version = sdk.default_platform();
             Ok(android::gen_minimal_android_manifest(
@@ -153,23 +145,22 @@ impl BuildContext {
     }
 
     pub fn gen_info_plist(&self, package_name: &String) -> Result<InfoPlist> {
-        if let Some(metadata) = &self.cargo_package.metadata {
-            if metadata.use_info_plist {
-                let path = metadata
-                    .info_plist_path
+        if self.metadata.use_info_plist {
+            let path = self
+                .metadata
+                .info_plist_path
+                .clone()
+                .unwrap_or_else(|| self.project_path.join("Info.plist"));
+            Ok(apple::read_info_plist(&path)?)
+        } else if !self.metadata.use_info_plist {
+            Ok(apple::gen_minimal_info_plist(
+                package_name,
+                self.metadata.app_name.clone(),
+                self.metadata
+                    .version_name
                     .clone()
-                    .unwrap_or_else(|| self.project_path.join("Info.plist"));
-                Ok(apple::read_info_plist(&path)?)
-            } else {
-                Ok(apple::gen_minimal_info_plist(
-                    package_name,
-                    metadata.app_name.clone(),
-                    metadata
-                        .version_name
-                        .clone()
-                        .unwrap_or(self.package_version()),
-                ))
-            }
+                    .unwrap_or(self.package_version()),
+            ))
         } else {
             Ok(apple::gen_minimal_info_plist(
                 package_name,
@@ -183,15 +174,10 @@ impl BuildContext {
         if !build_targets.is_empty() {
             return build_targets.clone();
         };
-        if self.cargo_package.metadata.is_none() {
+        if self.metadata.apple_build_targets.is_none() {
             return vec![AppleTarget::X86_64AppleIos];
         };
-        let targets = self
-            .cargo_package
-            .metadata
-            .clone()
-            .unwrap()
-            .apple_build_targets;
+        let targets = self.metadata.clone().apple_build_targets;
         if targets.is_some() && !targets.as_ref().unwrap().is_empty() {
             return targets.unwrap();
         };
@@ -199,18 +185,10 @@ impl BuildContext {
     }
 
     pub fn apple_res(&self) -> Option<PathBuf> {
-        self.cargo_package
-            .metadata
-            .as_ref()
-            .map(|m| m.apple_res.clone())
-            .unwrap_or_default()
+        self.metadata.apple_res.clone()
     }
 
     pub fn apple_assets(&self) -> Option<PathBuf> {
-        self.cargo_package
-            .metadata
-            .as_ref()
-            .map(|m| m.apple_assets.clone())
-            .unwrap_or_default()
+        self.metadata.apple_assets.clone()
     }
 }

--- a/crossbundle/cli/src/error.rs
+++ b/crossbundle/cli/src/error.rs
@@ -24,8 +24,6 @@ pub enum Error {
     Io(#[from] std::io::Error),
     /// Clap error
     Clap(#[from] clap::Error),
-    /// Cargo toml parse error
-    CargoToml(#[from] cargo_toml::Error),
     /// Crossbundle Tools error
     CrossbundleTools(#[from] crossbundle_tools::error::Error),
     /// AndroidManifest error

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -31,8 +31,6 @@ log = "0.4"
 zip = "0.5.13"
 zip-extensions = "0.6"
 tempfile = "3.2"
-
-
 cargo = "0.59.0"
 cargo-util = "0.1.1"
 

--- a/crossbundle/tools/src/commands/common/mod.rs
+++ b/crossbundle/tools/src/commands/common/mod.rs
@@ -2,9 +2,11 @@
 mod create_project;
 mod find_cargo_manifest_path;
 mod gen_minimal_project;
+mod parse_manifest;
 mod rust_compile;
 
 pub use create_project::*;
 pub use find_cargo_manifest_path::*;
 pub use gen_minimal_project::*;
+pub use parse_manifest::*;
 pub use rust_compile::*;

--- a/crossbundle/tools/src/commands/common/parse_manifest.rs
+++ b/crossbundle/tools/src/commands/common/parse_manifest.rs
@@ -7,11 +7,11 @@ use cargo::{
 use std::path::Path;
 
 pub fn parse_manifest(manifest_path: &Path) -> crate::error::Result<Manifest> {
-    let source_id = SourceId::for_path(&manifest_path)
+    let source_id = SourceId::for_path(manifest_path)
         .map_err(|_| Error::msg("Failed to create source_id from filesystem path"))?;
     let cargo_config =
         Config::default().map_err(|_| Error::msg("Failed to create a new config instance"))?;
-    let either_manifest = read_manifest(&manifest_path, source_id, &cargo_config)
+    let either_manifest = read_manifest(manifest_path, source_id, &cargo_config)
         .map_err(|_| Error::msg("Failed to read. Check the path to the manifest"))?
         .0;
     let manifest = match either_manifest {

--- a/crossbundle/tools/src/commands/common/parse_manifest.rs
+++ b/crossbundle/tools/src/commands/common/parse_manifest.rs
@@ -6,6 +6,7 @@ use cargo::{
 };
 use std::path::Path;
 
+/// Read manifest files and deserialize it
 pub fn parse_manifest(manifest_path: &Path) -> crate::error::Result<Manifest> {
     let source_id = SourceId::for_path(manifest_path)
         .map_err(|_| Error::msg("Failed to create source_id from filesystem path"))?;

--- a/crossbundle/tools/src/commands/common/parse_manifest.rs
+++ b/crossbundle/tools/src/commands/common/parse_manifest.rs
@@ -1,0 +1,25 @@
+use anyhow::Error;
+use cargo::{
+    core::{EitherManifest, Manifest, SourceId},
+    util::toml::read_manifest,
+    Config,
+};
+use std::path::Path;
+
+pub fn parse_manifest(manifest_path: &Path) -> crate::error::Result<Manifest> {
+    let source_id = SourceId::for_path(&manifest_path)
+        .map_err(|_| Error::msg("Failed to create source_id from filesystem path"))?;
+    let cargo_config =
+        Config::default().map_err(|_| Error::msg("Failed to create a new config instance"))?;
+    let either_manifest = read_manifest(&manifest_path, source_id, &cargo_config)
+        .map_err(|_| Error::msg("Failed to read. Check the path to the manifest"))?
+        .0;
+    let manifest = match either_manifest {
+        EitherManifest::Real(manifest) => manifest,
+        _ => {
+            let description = String::from("Received a virtual Cargo.toml data.");
+            return Err(crate::error::Error::FailedToFindManifest(description));
+        }
+    };
+    Ok(manifest)
+}

--- a/crossbundle/tools/src/error.rs
+++ b/crossbundle/tools/src/error.rs
@@ -83,7 +83,7 @@ pub enum Error {
         cause: std::io::Error,
     },
     /// Failed to find the manifest in path: {0}
-    FailedToFindManifest(String),
+    FailedToFindManifest(PathBuf),
     /// Invalid profile: {0}
     InvalidProfile(String),
     /// Invalid interface orientation: {0:?}

--- a/crossbundle/tools/src/error.rs
+++ b/crossbundle/tools/src/error.rs
@@ -82,6 +82,8 @@ pub enum Error {
         path: PathBuf,
         cause: std::io::Error,
     },
+    /// Failed to find the manifest in path: {0}
+    FailedToFindManifest(String),
     /// Invalid profile: {0}
     InvalidProfile(String),
     /// Invalid interface orientation: {0:?}

--- a/crossbundle/tools/tests/aab_full.rs
+++ b/crossbundle/tools/tests/aab_full.rs
@@ -17,7 +17,7 @@ fn test_aab_full() {
 
     // Assigns configuration for project
     let macroquad_project = false;
-    let package_name = gen_minimal_project(&project_path, macroquad_project).unwrap();
+    let package_name = gen_minimal_project(project_path, macroquad_project).unwrap();
     let sdk = AndroidSdk::from_env().unwrap();
     let ndk = AndroidNdk::from_env(Some(sdk.sdk_path())).unwrap();
     let target_sdk_version = 30;
@@ -31,7 +31,7 @@ fn test_aab_full() {
     android::compile_rust_for_android(
         &ndk,
         build_target,
-        &project_path,
+        project_path,
         profile,
         vec![],
         false,

--- a/crossbundle/tools/tests/add_libs.rs
+++ b/crossbundle/tools/tests/add_libs.rs
@@ -14,7 +14,7 @@ fn add_libs_into_aapt2_test() {
     let project_path = tempdir.path();
 
     // Assigns configuration for project
-    let macroquad_project = true;
+    let macroquad_project = false;
     let package_name = gen_minimal_project(&project_path, macroquad_project).unwrap();
 
     // Assigns configuration for project

--- a/crossbundle/tools/tests/add_libs.rs
+++ b/crossbundle/tools/tests/add_libs.rs
@@ -15,7 +15,7 @@ fn add_libs_into_aapt2_test() {
 
     // Assigns configuration for project
     let macroquad_project = false;
-    let package_name = gen_minimal_project(&project_path, macroquad_project).unwrap();
+    let package_name = gen_minimal_project(project_path, macroquad_project).unwrap();
 
     // Assigns configuration for project
     let sdk = AndroidSdk::from_env().unwrap();
@@ -31,7 +31,7 @@ fn add_libs_into_aapt2_test() {
     compile_rust_for_android(
         &ndk,
         build_target,
-        &project_path,
+        project_path,
         profile,
         vec![],
         false,

--- a/crossbundle/tools/tests/android_full.rs
+++ b/crossbundle/tools/tests/android_full.rs
@@ -15,7 +15,7 @@ fn test_android_full() {
     let tempdir = tempfile::tempdir().unwrap();
     let dir = tempdir.path();
     let macroquad_project = true;
-    let package_name = gen_minimal_project(&dir, macroquad_project).unwrap();
+    let package_name = gen_minimal_project(dir, macroquad_project).unwrap();
 
     // Create dependencies
     let sdk = AndroidSdk::from_env().unwrap();
@@ -29,7 +29,7 @@ fn test_android_full() {
     android::compile_rust_for_android(
         &ndk,
         build_target,
-        &dir,
+        dir,
         profile,
         vec![],
         false,
@@ -69,7 +69,7 @@ fn test_android_full() {
     // Gen unaligned apk
     let unaligned_apk_path = android::gen_unaligned_apk(
         &sdk,
-        &dir,
+        dir,
         &apk_build_dir,
         &manifest_path,
         None,

--- a/crossbundle/tools/tests/bundletool.rs
+++ b/crossbundle/tools/tests/bundletool.rs
@@ -125,7 +125,7 @@ fn build_bundle_test() {
             let extracted_files = extract_archive(&apk_path, &output_dir).unwrap();
 
             // Generates zip archive from extracted files
-            let gen_zip_modules = gen_zip_modules(&build_dir, "test", &extracted_files).unwrap();
+            let gen_zip_modules = gen_zip_modules(build_dir, "test", &extracted_files).unwrap();
             let aab = build_dir.join(format!("{}_unsigned.aab", package_name));
 
             // Builds app bundle

--- a/crossbundle/tools/tests/gen_apple_app.rs
+++ b/crossbundle/tools/tests/gen_apple_app.rs
@@ -15,5 +15,5 @@ fn test_gen_apple_app() {
     let app_dir =
         gen_apple_app_folder(&target_dir, &name, Default::default(), Default::default()).unwrap();
     // Check app dir
-    assert_eq!(true, app_dir.exists());
+    assert!(app_dir.exists());
 }

--- a/crossbundle/tools/tests/rust_compile.rs
+++ b/crossbundle/tools/tests/rust_compile.rs
@@ -12,7 +12,7 @@ fn test_compile_android() {
     let tempdir = tempfile::tempdir().unwrap();
     let dir = tempdir.path();
     let macroquad_project = true;
-    let package_name = gen_minimal_project(&dir, macroquad_project).unwrap();
+    let package_name = gen_minimal_project(dir, macroquad_project).unwrap();
 
     // Create dependencies
     let sdk = AndroidSdk::from_env().unwrap();
@@ -26,7 +26,7 @@ fn test_compile_android() {
     android::compile_rust_for_android(
         &ndk,
         build_target,
-        &dir,
+        dir,
         profile,
         vec![],
         false,

--- a/docs/main-hello-world.md
+++ b/docs/main-hello-world.md
@@ -70,4 +70,3 @@ crossbundle log android
 ```
 
 and you will see the message: `"Hello, project-name!"`
-


### PR DESCRIPTION
Replace cargo_toml library with cargo inner TomlManifest allows getting rid of dependence on `Cargo.toml `

Closes #73 