### PR TITLE
Bump subxt version

### DIFF
--- a/docs/using-subxt-with-bevy.md
+++ b/docs/using-subxt-with-bevy.md
@@ -6,13 +6,13 @@
 
 ```sh
 [dependencies]
-substrate-subxt = "0.15"
+substrate-subxt = "0.21"
 bevy = "0.7.0"
 ```
 
 ## ❗ Bevy explorer example
 
-To learn how to use subxt with bevy engine, you can go to the examples/bevy-explorer or install bevy explorer template. Follow next steps:
+To learn how to use subxt with bevy engine, you can go to the [examples/bevy-explorer](https://github.com/dodorare/crossbow/tree/main/examples/bevy-explorer) or install bevy explorer template. Follow next steps:
 
 1. Install cargo-generate:
 

--- a/examples/bevy-explorer/Cargo.toml
+++ b/examples/bevy-explorer/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 crossbow = { version = "0.1.0", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
-subxt = "0.20"
+subxt = "0.21"
 tokio = { version = "1.17", features = ["sync", "macros", "rt-multi-thread"] }
 bevy = { version = "0.7.0", features = ["mp3"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
-jsonrpsee = { version = "0.9.0", features = ["async-client", "client-ws-transport"] }
+jsonrpsee = { version = "0.10.1", features = ["async-client", "client-ws-transport"] }
 
 [package.metadata]
 app_name = "Bevy Explorer"

--- a/examples/bevy-explorer/src/explorer.rs
+++ b/examples/bevy-explorer/src/explorer.rs
@@ -1,11 +1,12 @@
 use bevy::{prelude::*, tasks::AsyncComputeTaskPool};
-use subxt::{ClientBuilder, DefaultConfig, SubstrateExtrinsicParams};
+use jsonrpsee::core::client::CertificateStore;
+use subxt::{ClientBuilder, DefaultConfig, SubstrateExtrinsicParams, rpc::{Uri, WsTransportClientBuilder, RpcClientBuilder}};
 use tokio::sync::mpsc;
 
-use jsonrpsee::{
-    client_transport::ws::{Uri, WsTransportClientBuilder},
-    core::client::{CertificateStore, ClientBuilder as RpcClientBuilder},
-};
+// use jsonrpsee::{
+//     client_transport::ws::{Uri, WsTransportClientBuilder},
+//     core::client::{CertificateStore, ClientBuilder as RpcClientBuilder},
+// };
 
 #[subxt::subxt(runtime_metadata_path = "res/metadata.scale")]
 pub mod bevy_explorer {}

--- a/examples/bevy-explorer/src/main.rs
+++ b/examples/bevy-explorer/src/main.rs
@@ -6,7 +6,7 @@ use bevy::{core::FixedTimestep, prelude::*};
 use explorer::*;
 
 fn main() {
-    println!("Initialization.");
+    info!("Initialization.");
     std::thread::sleep(std::time::Duration::from_secs(2));
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))


### PR DESCRIPTION
 Subxt version was bumped from "0.20.0" to "0.21.0". Make edits to the documentation and refactor some code. Bevy explorer was checked on windows and android. 