### PR TITLE
Fix example for windows

### DIFF
--- a/crossbundle/tools/src/utils/shell.rs
+++ b/crossbundle/tools/src/utils/shell.rs
@@ -32,7 +32,7 @@ impl TtyWidth {
 }
 
 /// The requested verbosity of output.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verbosity {
     Verbose,
     Normal,
@@ -82,7 +82,7 @@ enum ShellOut {
 }
 
 /// Whether messages should use color output
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ColorChoice {
     /// Force color output
     Always,

--- a/examples/macroquad-permissions/src/main.rs
+++ b/examples/macroquad-permissions/src/main.rs
@@ -1,6 +1,9 @@
+#[cfg(target_os = "android")]
 use crossbow::crossbow_permissions::prelude::*;
+
 use macroquad::prelude::*;
 use macroquad::ui::{hash, root_ui, Skin};
+
 
 #[macroquad::main("Macroquad UI")]
 async fn main() -> anyhow::Result<()> {
@@ -49,10 +52,12 @@ async fn main() -> anyhow::Result<()> {
         root_ui().push_skin(&window_skin);
         root_ui().window(hash!(), vec2(0.0, 250.0), vec2(500.0, 500.0), |ui| {
             if ui.button(vec2(-15.0, 150.0), "Ask camera permission") {
+                #[cfg(target_os = "android")]
                 request_permission(Permission::AndroidPermission(AndroidPermission::Camera))
                     .unwrap();
             }
             if ui.button(vec2(-15.0, 300.0), "Ask storage permission") {
+                #[cfg(target_os = "android")]
                 request_permission(Permission::AndroidPermission(
                     AndroidPermission::ReadExternalStorage,
                 ))

--- a/examples/macroquad-permissions/src/main.rs
+++ b/examples/macroquad-permissions/src/main.rs
@@ -4,7 +4,6 @@ use crossbow::crossbow_permissions::prelude::*;
 use macroquad::prelude::*;
 use macroquad::ui::{hash, root_ui, Skin};
 
-
 #[macroquad::main("Macroquad UI")]
 async fn main() -> anyhow::Result<()> {
     let skin = {


### PR DESCRIPTION
It was added derive macros for Android request_permission() function to fix macroquad-permissions example building for Windows. 