### PR TITLE
Fix android build on Windows, start_apk function and Kotlin linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,16 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 11
+      - name: Install gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          distribution: temurin
+          gradle-version: 7.4
       - name: Install Apple targets
         run: |
           rustup upgrade

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform Rust Toolkit for Games 🏹"
@@ -12,7 +12,7 @@ exclude = [".github/**/*"]
 
 [dependencies]
 # Platform-specific dependencies
-crossbow-android = { path = "platform/android", version = "0.1.5", optional = true }
+crossbow-android = { path = "platform/android", version = "0.1.6", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = "0.6.2"

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbundle"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Build and publish apps for Android/iOS"
@@ -18,7 +18,7 @@ name = "crossbundle"
 path = "src/main.rs"
 
 [dependencies]
-crossbundle-tools = { path = "../tools", version = "0.1.5" }
+crossbundle-tools = { path = "../tools", version = "0.1.6" }
 android-tools = "0.2.8"
 clap = { version = "3.2.8", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -9,6 +9,7 @@ use crossbundle_tools::{
     tools::*,
     types::*,
     utils::Config,
+    error::CommandExt,
 };
 use std::path::{Path, PathBuf};
 
@@ -112,6 +113,14 @@ impl AndroidBuildCommand {
             "Gradle project generated",
             gradle_project_path.to_str().unwrap(),
         )?;
+
+        config.status("Building Gradle project")?;
+        let mut gradle = android::gradle_init()?;
+        gradle
+            .arg("build")
+            .arg("-p")
+            .arg(dunce::simplified(&gradle_project_path));
+        gradle.output_err(true)?;
         Ok((android_manifest, sdk, gradle_project_path))
     }
 

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -6,10 +6,10 @@ use android_tools::java_tools::{AabKey, JarSigner};
 use clap::Parser;
 use crossbundle_tools::{
     commands::android::{self, rust_compile},
+    error::CommandExt,
     tools::*,
     types::*,
     utils::Config,
-    error::CommandExt,
 };
 use std::path::{Path, PathBuf};
 

--- a/crossbundle/cli/src/commands/run/android.rs
+++ b/crossbundle/cli/src/commands/run/android.rs
@@ -34,7 +34,11 @@ impl AndroidRunCommand {
             config.status("Installing APKs file")?;
             InstallApks::new(&apks_path).run()?;
             config.status("Starting APK file")?;
-            android::start_apk(&sdk, &android_manifest.package)?;
+            android::start_apk(
+                &sdk,
+                &android_manifest.package,
+                "android.app.NativeActivity",
+            )?;
             config.status("Run finished successfully")?;
         } else if self.build_command.lib.is_some() {
             config.status("Can not run dynamic library")?;
@@ -45,7 +49,11 @@ impl AndroidRunCommand {
             config.status("Installing APK file")?;
             android::install_apk(&sdk, &apk_path)?;
             config.status("Starting APK file")?;
-            android::start_apk(&sdk, &android_manifest.package)?;
+            android::start_apk(
+                &sdk,
+                &android_manifest.package,
+                "android.app.NativeActivity",
+            )?;
             config.status("Run finished successfully")?;
         } else {
             let (android_manifest, sdk, gradle_project_path) = self.build_command.build_gradle(
@@ -61,7 +69,11 @@ impl AndroidRunCommand {
                 .arg(dunce::simplified(&gradle_project_path));
             gradle.output_err(true)?;
             config.status("Starting APK file")?;
-            android::start_apk(&sdk, &android_manifest.package)?;
+            android::start_apk(
+                &sdk,
+                &android_manifest.package,
+                "com.crossbow.game.CrossbowApp",
+            )?;
             config.status("Run finished successfully")?;
         }
         Ok(())

--- a/crossbundle/cli/src/types/mod.rs
+++ b/crossbundle/cli/src/types/mod.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Metadata {
+    #[serde(default)]
     pub android: AndroidConfig,
+    #[serde(default)]
     pub apple: AppleConfig,
 }

--- a/crossbundle/cli/tests/cargo_metadata.rs
+++ b/crossbundle/cli/tests/cargo_metadata.rs
@@ -78,16 +78,8 @@ fn test_cargo_metadata() {
       </intent-filter>
       <meta-data android:name="android.app.lib_name" android:value="example" />
     </activity>
-    <service android:name="UpdateService" />
-    <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
   </application>
   <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
-  <uses-feature android:name="android.hardware.vulkan.level" android:required="true" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="30" />
-  <uses-permission-sdk-23 android:name="android.permission.INTERNET" android:maxSdkVersion="30" />
-  <queries>
-    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" android:name="org.khronos.openxr" />
-  </queries>
 </manifest>
 "#;
     let expected_manifest = from_str(expected_manifest).unwrap();

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbundle-tools"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Build and publish apps for Android/iOS"

--- a/crossbundle/tools/src/commands/android/generate/gen_gradle_project.rs
+++ b/crossbundle/tools/src/commands/android/generate/gen_gradle_project.rs
@@ -147,7 +147,7 @@ fn get_settings_gradle(dependencies: &[GradleDependencyProject]) -> Result<Strin
                 "{}project(\"{}\").projectDir = new File(\"{}\")\n",
                 result,
                 dependency.include,
-                dir_path.to_string_lossy()
+                dir_path.as_os_str().to_str().unwrap()
             );
         }
     }

--- a/crossbundle/tools/src/commands/android/generate/gen_gradle_project.rs
+++ b/crossbundle/tools/src/commands/android/generate/gen_gradle_project.rs
@@ -144,10 +144,10 @@ fn get_settings_gradle(dependencies: &[GradleDependencyProject]) -> Result<Strin
                 );
             }
             result = format!(
-                "{}project(\"{}\").projectDir = new File(\"{}\")\n",
+                "{}project(\"{}\").projectDir = new File({:?})\n",
                 result,
                 dependency.include,
-                dir_path.as_os_str().to_str().unwrap()
+                dir_path.to_string_lossy()
             );
         }
     }

--- a/crossbundle/tools/src/commands/android/start_apk.rs
+++ b/crossbundle/tools/src/commands/android/start_apk.rs
@@ -3,7 +3,7 @@ use crate::tools::AndroidSdk;
 
 /// Starts installed APK or AAB on emulator or connected device.
 /// Runs `adb shell am start ...` command
-pub fn start_apk(sdk: &AndroidSdk, package: &str) -> Result<()> {
+pub fn start_apk(sdk: &AndroidSdk, package: &str, activity: &str) -> Result<()> {
     let mut adb = sdk.platform_tool(bin!("adb"))?;
     adb.arg("shell")
         .arg("am")
@@ -11,7 +11,7 @@ pub fn start_apk(sdk: &AndroidSdk, package: &str) -> Result<()> {
         .arg("-a")
         .arg("android.intent.action.MAIN")
         .arg("-n")
-        .arg(format!("{}/android.app.NativeActivity", package));
+        .arg(format!("{}/activity", package, activity));
     adb.output_err(true)?;
     Ok(())
 }

--- a/crossbundle/tools/src/commands/android/start_apk.rs
+++ b/crossbundle/tools/src/commands/android/start_apk.rs
@@ -11,7 +11,7 @@ pub fn start_apk(sdk: &AndroidSdk, package: &str, activity: &str) -> Result<()> 
         .arg("-a")
         .arg("android.intent.action.MAIN")
         .arg("-n")
-        .arg(format!("{}/activity", package, activity));
+        .arg(format!("{}/{}", package, activity));
     adb.output_err(true)?;
     Ok(())
 }

--- a/crossbundle/tools/src/commands/common/gen_minimal_project/consts.rs
+++ b/crossbundle/tools/src/commands/common/gen_minimal_project/consts.rs
@@ -24,6 +24,30 @@ anyhow = "1.0"
 macroquad = "0.3.7"
 "#;
 
+pub const MINIMAL_MQ_GRADLE_CARGO_TOML_VALUE: &str = r#"
+[package]
+name = "example"
+version = "0.1.0"
+authors = ["DodoRare Team <support@dodorare.com>"]
+edition = "2021"
+
+[dependencies]
+crossbow = { git = "https://github.com/dodorare/crossbow" }
+anyhow = "1.0"
+macroquad = "0.3.7"
+
+[package.metadata.android]
+target_sdk_version = 30
+
+[[package.metadata.android.plugins_local_projects]]
+include = ":crossbow"
+dont_implement = true
+project_dir = "../../platform/android/java"
+
+[[package.metadata.android.plugins_local_projects]]
+include = ":crossbow:lib"
+"#;
+
 pub const CARGO_TOML_VALUE: &str = r#"
 [package.metadata.android]
 app_name = "example"

--- a/crossbundle/tools/src/commands/common/gen_minimal_project/gen_min_project.rs
+++ b/crossbundle/tools/src/commands/common/gen_minimal_project/gen_min_project.rs
@@ -15,7 +15,7 @@ pub fn gen_minimal_project(
     let file_path = out_dir.join("Cargo.toml");
     let mut file = File::create(file_path)?;
     if macroquad_project {
-        file.write_all(MINIMAL_MQ_CARGO_TOML_VALUE.as_bytes())?;
+        file.write_all(MINIMAL_MQ_GRADLE_CARGO_TOML_VALUE.as_bytes())?;
     } else {
         file.write_all(MINIMAL_BEVY_CARGO_TOML_VALUE.as_bytes())?;
     }

--- a/crossbundle/tools/src/commands/common/gen_minimal_project/gen_min_project.rs
+++ b/crossbundle/tools/src/commands/common/gen_minimal_project/gen_min_project.rs
@@ -16,11 +16,10 @@ pub fn gen_minimal_project(
     let mut file = File::create(file_path)?;
     if macroquad_project {
         file.write_all(MINIMAL_MQ_GRADLE_CARGO_TOML_VALUE.as_bytes())?;
+    } else if !minimal_cargo_toml {
+        file.write_all(CARGO_TOML_VALUE.as_bytes())?;
     } else {
         file.write_all(MINIMAL_BEVY_CARGO_TOML_VALUE.as_bytes())?;
-    }
-    if !minimal_cargo_toml {
-        file.write_all(CARGO_TOML_VALUE.as_bytes())?;
     }
     // Create src folder
     let src_path = out_dir.join("src");

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,9 @@ allow = [
     "Apache-2.0",
     "BSD-3-Clause",
 ]
+exceptions = [
+    { name = "unicode-ident", allow = ["Unicode-DFS-2016"] },
+]
 default = "deny"
 
 [[licenses.clarify]]

--- a/examples/bevy-2d/Cargo.toml
+++ b/examples/bevy-2d/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy-2d"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.5", path = "../../" }
+crossbow = { version = "0.1.6", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 bevy = { version = "0.7.0", features = ["mp3"] }

--- a/examples/bevy-3d/Cargo.toml
+++ b/examples/bevy-3d/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy-3d"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.5", path = "../../" }
+crossbow = { version = "0.1.6", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 bevy = "0.7.0"

--- a/examples/bevy-explorer/Cargo.toml
+++ b/examples/bevy-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-explorer"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 

--- a/examples/macroquad-3d/Cargo.toml
+++ b/examples/macroquad-3d/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "macroquad-3d"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.5", path = "../../" }
+crossbow = { version = "0.1.6", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 macroquad = "0.3.7"

--- a/examples/macroquad-permissions/Cargo.toml
+++ b/examples/macroquad-permissions/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "macroquad-permissions"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.5", path = "../../" }
-crossbow-admob = { version = "0.1.5", path = "../../plugins/admob" }
+crossbow = { version = "0.1.6", path = "../../" }
+crossbow-admob = { version = "0.1.6", path = "../../plugins/admob" }
 log = "0.4"
 anyhow = "1.0"
 macroquad = "0.3.7"
@@ -23,7 +23,7 @@ build_targets = ["aarch64-linux-android"]
 assets = "assets"
 res = "res/android"
 
-# plugins_remote = ["com.crossbow.admob:admob:0.1.5"]
+# plugins_remote = ["com.crossbow.admob:admob:0.1.6"]
 
 [[package.metadata.android.plugins_local_projects]]
 include = ":crossbow"

--- a/platform/android/Cargo.toml
+++ b/platform/android/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow-android"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform Rust Toolkit for Games 🏹"

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 
     if (rootProject.findProject(":lib")) {
         implementation project(":lib")
+    } else if (rootProject.findProject(":crossbow:lib")) {
+        implementation project(":crossbow:lib")
     } else if (getCustomBuildMode()) {
         // Custom build mode. In this scenario this project is the only one around and the Crossbow
         // library is available through the pre-generated crossbow-lib.*.aar android archive files.

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    crossbowLibrary    : "0.1.5",
+    crossbowLibrary    : "0.1.6",
     androidGradlePlugin: "7.0.0",
     compileSdk         : 31,
     minSdk             : 19,

--- a/platform/android/java/lib/src/com/crossbow/library/CrossbowLib.kt
+++ b/platform/android/java/lib/src/com/crossbow/library/CrossbowLib.kt
@@ -15,6 +15,7 @@ object CrossbowLib {
     /**
      * Invoked on the main thread to initialize Godot native layer.
      */
+    @JvmStatic
     external fun initialize(
         activity: Activity?,
         instance: Crossbow?,
@@ -25,11 +26,13 @@ object CrossbowLib {
     //  * Invoked on the main thread to clean up Godot native layer.
     //  * @see androidx.fragment.app.Fragment.onDestroy
     //  */
+    // @JvmStatic
     // external fun ondestroy()
 
     // /**
     //  * Forward [Activity.onBackPressed] event from the main thread to the GL thread.
     //  */
+    // @JvmStatic
     // external fun back()
 
     /**
@@ -38,5 +41,6 @@ object CrossbowLib {
      * @param permission Request permission
      * @param result True if the permission was granted, false otherwise
      */
+    @JvmStatic
     external fun requestPermissionResult(permission: String?, result: Boolean)
 }

--- a/platform/android/java/lib/src/com/crossbow/library/plugin/CrossbowPlugin.kt
+++ b/platform/android/java/lib/src/com/crossbow/library/plugin/CrossbowPlugin.kt
@@ -319,6 +319,7 @@ abstract class CrossbowPlugin(
          * Used to setup a [CrossbowPlugin] instance.
          * @param p_name Name of the instance.
          */
+        @JvmStatic
         private external fun nativeRegisterSingleton(p_name: String, p_obj: Any)
 
         /**
@@ -327,6 +328,7 @@ abstract class CrossbowPlugin(
          * @param p_name Name of the method to register
          * @param p_sig Signature of the registered method
          */
+        @JvmStatic
         private external fun nativeRegisterMethod(p_sname: String, p_name: String, p_sig: String)
 
         /**
@@ -335,6 +337,7 @@ abstract class CrossbowPlugin(
          * @param signalName Name of the signal to register
          * @param signalParamTypes Signal parameters types
          */
+        @JvmStatic
         private external fun nativeRegisterSignal(
             pluginName: String,
             signalName: String,
@@ -347,6 +350,7 @@ abstract class CrossbowPlugin(
          * @param signalName Name of the signal to emit
          * @param signalParams Signal parameters
          */
+        @JvmStatic
         private external fun nativeEmitSignal(
             pluginName: String,
             signalName: String,

--- a/platform/android/java/lib/src/com/crossbow/library/plugin/CrossbowPlugin.kt
+++ b/platform/android/java/lib/src/com/crossbow/library/plugin/CrossbowPlugin.kt
@@ -319,7 +319,7 @@ abstract class CrossbowPlugin(
          * Used to setup a [CrossbowPlugin] instance.
          * @param p_name Name of the instance.
          */
-        private external fun nativeRegisterSingleton(p_name: String, `object`: Any)
+        private external fun nativeRegisterSingleton(p_name: String, p_obj: Any)
 
         /**
          * Used to complete registration of the [CrossbowPlugin] instance's methods.

--- a/platform/android/java/lib/src/com/crossbow/library/plugin/SignalInfo.kt
+++ b/platform/android/java/lib/src/com/crossbow/library/plugin/SignalInfo.kt
@@ -17,7 +17,7 @@ class SignalInfo(signalName: String, vararg argParamTypes: Class<*>) {
     init {
         require(!TextUtils.isEmpty(signalName)) { "Invalid signal name: $signalName" }
         name = signalName
-        paramTypes = arrayOf(*argParamTypes) // ?: arrayOfNulls(0)
+        paramTypes = arrayOf(*argParamTypes)
         val tmpArray = arrayOfNulls<String>(paramTypes.size)
         for (i in paramTypes.indices) {
             val tmp = JNIUtil.getJNIClassSignature(paramTypes[i])

--- a/platform/android/java/lib/src/com/crossbow/library/plugin/SignalInfo.kt
+++ b/platform/android/java/lib/src/com/crossbow/library/plugin/SignalInfo.kt
@@ -18,13 +18,14 @@ class SignalInfo(signalName: String, vararg argParamTypes: Class<*>) {
         require(!TextUtils.isEmpty(signalName)) { "Invalid signal name: $signalName" }
         name = signalName
         paramTypes = arrayOf(*argParamTypes) // ?: arrayOfNulls(0)
-        paramTypesNames = arrayOfNulls<String?>(paramTypes.size).toTypedArray()
+        val tmpArray = arrayOfNulls<String>(paramTypes.size)
         for (i in paramTypes.indices) {
             val tmp = JNIUtil.getJNIClassSignature(paramTypes[i])
             if (tmp !== null) {
-                paramTypesNames[i] = tmp
+                tmpArray[i] = tmp
             }
         }
+        paramTypesNames = tmpArray.filterNotNull().toTypedArray()
     }
 
     override fun toString(): String {

--- a/platform/android/java/lib/src/com/crossbow/library/plugin/SignalInfo.kt
+++ b/platform/android/java/lib/src/com/crossbow/library/plugin/SignalInfo.kt
@@ -18,7 +18,7 @@ class SignalInfo(signalName: String, vararg argParamTypes: Class<*>) {
         require(!TextUtils.isEmpty(signalName)) { "Invalid signal name: $signalName" }
         name = signalName
         paramTypes = arrayOf(*argParamTypes) // ?: arrayOfNulls(0)
-        paramTypesNames = arrayOfNulls<String?>(paramTypes.size).filterNotNull().toTypedArray()
+        paramTypesNames = arrayOfNulls<String?>(paramTypes.size).toTypedArray()
         for (i in paramTypes.indices) {
             val tmp = JNIUtil.getJNIClassSignature(paramTypes[i])
             if (tmp !== null) {

--- a/platform/android/src/externs/mod.rs
+++ b/platform/android/src/externs/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod crossbow_lib;
-pub(crate) mod crossbow_plugin;
+pub mod crossbow_lib;
+pub mod crossbow_plugin;

--- a/plugins/admob/Cargo.toml
+++ b/plugins/admob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow-admob"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "AdMob Plugin for Crossbow"
@@ -10,4 +10,4 @@ keywords = ["crossbow", "google", "admob", "android", "ads"]
 readme = "README.md"
 
 [dependencies]
-crossbow-android = { path = "../../platform/android", version = "0.1.5" }
+crossbow-android = { path = "../../platform/android", version = "0.1.6" }

--- a/plugins/admob/README.md
+++ b/plugins/admob/README.md
@@ -22,15 +22,15 @@ Just add Rust dependencies like this:
 
 ```toml
 [dependencies]
-crossbow = "0.1.5"
-crossbow-admob = "0.1.5"
+crossbow = "0.1.6"
+crossbow-admob = "0.1.6"
 ```
 
 And finally, add this to your Crossbow Android configuration:
 
 ```toml
 [package.metadata.android]
-plugins_remote = ["com.crossbow.admob:admob:0.1.5"]
+plugins_remote = ["com.crossbow.admob:admob:0.1.6"]
 ```
 
 > That's it, now you can start using AdMob ads!

--- a/plugins/admob/android/config.gradle
+++ b/plugins/admob/android/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    crossbowLibrary    : "0.1.5",
+    crossbowLibrary    : "0.1.6",
     androidGradlePlugin: "7.0.0",
     compileSdk         : 31,
     minSdk             : 19,


### PR DESCRIPTION
# Objective

- Build for android was failing on Windows because of the Path display.
- Kotlin linking was incorrect.
- Function `start_apk` didn't launch the Application if it was built with Gradle.
- Default command `crossbundle build android` actually doesn't build apk.
- Cargo Metadata and Gradle tests were failing.

## Solution

- Use Path with Debug formatting.
- Use `@JvmStatic` for Kotlin external functions.
- Add an argument to the `start_apk` function to specify the Activity to launch.
- Launch the `gradle build` command at the end of the crossbundle build command.
- Fix tests `test_cargo_metadata` and `test_build_gradle`.

## Changelog

**Important:** This change will update all libraries to the 0.1.6 version.
