### PR TITLE
Fix issue with install several packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       run: |
         rustup upgrade
         rustup target add aarch64-linux-android x86_64-linux-android
+    - name: Setup NDK path
+      shell: bash
+      run: echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
     - name: Install Crossbundle
       run: |
         cargo install --path=./crossbundle/cli

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 crossbundle-tools = { path = "../tools", version = "0.1.6" }
-android-tools = { git = "https://github.com/dodorare/android-tools-rs", branch = "android-sdk"}
+android-tools = "0.2.9"
 clap = { version = "3.2.8", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 crossbundle-tools = { path = "../tools", version = "0.1.6" }
-android-tools = "0.2.8"
+android-tools = { git = "https://github.com/dodorare/android-tools-rs", branch = "android-sdk"}
 clap = { version = "3.2.8", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -90,7 +90,6 @@ impl AndroidBuildCommand {
         };
 
         config.status("Generating gradle project")?;
-        println!("{}", sdk_install_path()?.to_str().unwrap().to_string());
         std::env::set_var(
             "ANDROID_SDK_ROOT",
             sdk_install_path()?.to_str().unwrap().to_string(),

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -2,7 +2,10 @@ use crate::types::MIN_SDK_VERSION;
 
 use super::{BuildContext, SharedBuildCommand};
 use android_manifest::AndroidManifest;
-use android_tools::java_tools::{AabKey, JarSigner};
+use android_tools::{
+    java_tools::{JarSigner, Key},
+    sdk_install_path,
+};
 use clap::Parser;
 use crossbundle_tools::{
     commands::android::{self, rust_compile},
@@ -87,6 +90,11 @@ impl AndroidBuildCommand {
         };
 
         config.status("Generating gradle project")?;
+        println!("{}", sdk_install_path()?.to_str().unwrap().to_string());
+        std::env::set_var(
+            "ANDROID_SDK_ROOT",
+            sdk_install_path()?.to_str().unwrap().to_string(),
+        );
         let gradle_project_path = android::gen_gradle_project(
             &android_build_dir,
             &context.android_config.assets,
@@ -283,7 +291,7 @@ impl AndroidBuildCommand {
         &self,
         config: &Config,
         context: &BuildContext,
-    ) -> crate::error::Result<(AndroidManifest, AndroidSdk, PathBuf, String, AabKey)> {
+    ) -> crate::error::Result<(AndroidManifest, AndroidSdk, PathBuf, String, Key)> {
         let profile = self.shared.profile();
         let example = self.shared.example.as_ref();
         let (project_path, target_dir, package_name) = Self::needed_project_dirs(example, context)?;
@@ -466,9 +474,9 @@ impl AndroidBuildCommand {
         sign_key_path: Option<PathBuf>,
         sign_key_pass: Option<String>,
         sign_key_alias: Option<String>,
-    ) -> crate::error::Result<AabKey> {
+    ) -> crate::error::Result<Key> {
         let key = if let Some(key_path) = sign_key_path {
-            let aab_key = AabKey {
+            let aab_key = Key {
                 key_path,
                 key_pass: sign_key_pass.unwrap(),
                 key_alias: sign_key_alias.unwrap(),
@@ -483,7 +491,7 @@ impl AndroidBuildCommand {
                 )?
             }
         } else {
-            let aab_key = AabKey::new_default()?;
+            let aab_key = Key::new_default()?;
             if aab_key.key_path.exists() {
                 aab_key
             } else {

--- a/crossbundle/cli/src/commands/install/command_line_tools.rs
+++ b/crossbundle/cli/src/commands/install/command_line_tools.rs
@@ -1,8 +1,8 @@
 use super::*;
+use android_tools::sdk_install_path;
 use clap::Parser;
 use crossbundle_tools::{
     commands::android::{self, remove},
-    tools::AndroidSdk,
     utils::Config,
 };
 use std::path::{Path, PathBuf};
@@ -38,7 +38,7 @@ impl CommandLineToolsInstallCommand {
         )?;
         self.download_and_save_file(command_line_tools_download_url, &file_path)?;
 
-        let sdk_path = AndroidSdk::sdk_install_path()?;
+        let sdk_path = sdk_install_path()?;
         println!("sdk_path {:?}", sdk_path);
 
         if let Some(path) = &self.install_path {
@@ -52,7 +52,7 @@ impl CommandLineToolsInstallCommand {
                 "Extracting zip archive contents into",
                 &sdk_path.to_str().unwrap(),
             )?;
-            android::extract_archive(&file_path, &sdk_path)?;
+            android::extract_archive(&file_path, Path::new(&sdk_path))?;
         }
 
         config.status("Deleting zip archive was left after installation")?;

--- a/crossbundle/cli/src/commands/install/command_line_tools.rs
+++ b/crossbundle/cli/src/commands/install/command_line_tools.rs
@@ -39,7 +39,6 @@ impl CommandLineToolsInstallCommand {
         self.download_and_save_file(command_line_tools_download_url, &file_path)?;
 
         let sdk_path = sdk_install_path()?;
-        println!("sdk_path {:?}", sdk_path);
 
         if let Some(path) = &self.install_path {
             config.status_message(

--- a/crossbundle/cli/src/commands/install/sdkmanager.rs
+++ b/crossbundle/cli/src/commands/install/sdkmanager.rs
@@ -7,7 +7,7 @@ use crossbundle_tools::{
 
 #[derive(Parser, Clone, Debug, Default)]
 pub struct SdkManagerInstallCommand {
-    /// Install all preferred tools for correct crossbundle work
+    /// Install all preferred tools for correct crossbundle work. It will install build-tools;31.0.0, ndk;23.1.7779620 and platforms;android-30
     #[clap(long, short)]
     preferred_tools: bool,
     /// List installed and available packages. Use the channel option to include a package from a channel up to and including channel_id.
@@ -16,8 +16,8 @@ pub struct SdkManagerInstallCommand {
     list: bool,
     /// Install package. To see all available packages use --list.
     /// Example: crossbundle install sdk-manager "ndk;23.1.7779620"
-    #[clap(long, short)]
-    install: Option<String>,
+    #[clap(long, short, multiple_values = true)]
+    install: Option<Vec<String>>,
     /// Android package that needs to be uninstalled
     #[clap(long)]
     uninstall: Option<String>,
@@ -69,7 +69,7 @@ impl SdkManagerInstallCommand {
 
     /// Install package. To see all available packages use --list.
     /// Example: crossbundle install sdk-manager "ndk;23.1.7779620"
-    pub fn install(&mut self, install: String) -> &mut Self {
+    pub fn install(&mut self, install: Vec<String>) -> &mut Self {
         self.install = Some(install);
         self
     }
@@ -187,9 +187,8 @@ impl SdkManagerInstallCommand {
         } else {
             sdkmanager.arg(format!("--sdk_root={}", sdk_root.to_str().unwrap()));
         }
-        // TODO: Resolve the problem about installation several packages
         if let Some(install) = &self.install {
-            sdkmanager.arg(install);
+            sdkmanager.args(install);
         }
         if let Some(uninstall) = &self.uninstall {
             sdkmanager.arg("--uninstall").arg(uninstall);

--- a/crossbundle/cli/src/commands/install/sdkmanager.rs
+++ b/crossbundle/cli/src/commands/install/sdkmanager.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
+use android_tools::sdk_install_path;
 use clap::Parser;
-use crossbundle_tools::{
-    error::CommandExt, tools::AndroidSdk, utils::Config, EXECUTABLE_SUFFIX_BAT,
-};
+use crossbundle_tools::{error::CommandExt, utils::Config, EXECUTABLE_SUFFIX_BAT};
 
 #[derive(Parser, Clone, Debug, Default)]
 pub struct SdkManagerInstallCommand {
@@ -158,20 +157,23 @@ impl SdkManagerInstallCommand {
 
     /// Run sdkmanager command with specified flags and options
     pub fn run(&self, _config: &Config) -> crate::error::Result<()> {
-        let sdk_root = AndroidSdk::sdk_install_path()?;
+        let sdk_root = sdk_install_path()?;
         // Android studio install cmdline tools into SDK_ROOT/cmdline-tools/<version>/bin.
         // Crossbundle install command ignores <version> directory so we need convert cmd-line-tools path to Option<T> to avoid confusion
-        let cmdline_tools_path = sdk_root.join("cmdline-tools").join("latest").join("bin");
+        let cmdline_tools_path = std::path::PathBuf::from(&sdk_root)
+            .join("cmdline-tools")
+            .join("latest")
+            .join("bin");
         if cmdline_tools_path.exists() {
             let sdkmanager_path =
                 cmdline_tools_path.join(format!("sdkmanager{}", EXECUTABLE_SUFFIX_BAT));
-            self.sdkmanager_command(&sdkmanager_path, &sdk_root)?;
+            self.sdkmanager_command(&sdkmanager_path, Path::new(&sdk_root))?;
         } else {
-            let sdkmanager_path = sdk_root
+            let sdkmanager_path = std::path::PathBuf::from(&sdk_root)
                 .join("cmdline-tools")
                 .join("bin")
                 .join(format!("sdkmanager{}", EXECUTABLE_SUFFIX_BAT));
-            self.sdkmanager_command(&sdkmanager_path, &sdk_root)?;
+            self.sdkmanager_command(&sdkmanager_path, Path::new(&sdk_root))?;
         };
         Ok(())
     }

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -19,7 +19,7 @@ dirs = "4.0.0"
 simctl = { version = "0.1.1", package = "creator-simctl" }
 android-manifest = "0.1.8"
 apple-bundle = "0.1.1"
-android-tools = "0.2.8"
+android-tools = { git = "https://github.com/dodorare/android-tools-rs", branch = "android-sdk"}
 thiserror = "1.0"
 anyhow = "1.0"
 displaydoc = "0.2"

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -19,7 +19,7 @@ dirs = "4.0.0"
 simctl = { version = "0.1.1", package = "creator-simctl" }
 android-manifest = "0.1.8"
 apple-bundle = "0.1.1"
-android-tools = { git = "https://github.com/dodorare/android-tools-rs", branch = "android-sdk"}
+android-tools = "0.2.9"
 thiserror = "1.0"
 anyhow = "1.0"
 displaydoc = "0.2"

--- a/crossbundle/tools/src/commands/android/generate/gen_key.rs
+++ b/crossbundle/tools/src/commands/android/generate/gen_key.rs
@@ -1,4 +1,4 @@
-use android_tools::java_tools::{AabKey, KeyAlgorithm, Keytool};
+use android_tools::java_tools::{Key, KeyAlgorithm, Keytool};
 use std::path::PathBuf;
 
 /// Generates keystore with default configuration. You can manage configuration with
@@ -7,9 +7,9 @@ pub fn gen_key(
     sign_key_path: Option<PathBuf>,
     sign_key_pass: Option<String>,
     sign_key_alias: Option<String>,
-) -> crate::error::Result<AabKey> {
+) -> crate::error::Result<Key> {
     let key = if let Some(key_path) = sign_key_path {
-        let aab_key = AabKey {
+        let aab_key = Key {
             key_path,
             key_pass: sign_key_pass.unwrap(),
             key_alias: sign_key_alias.unwrap(),
@@ -33,7 +33,7 @@ pub fn gen_key(
                 .unwrap()
         }
     } else {
-        let aab_key = AabKey::new_default()?;
+        let aab_key = Key::new_default()?;
         if aab_key.key_path.exists() {
             aab_key
         } else {

--- a/crossbundle/tools/src/commands/android/sign_apk.rs
+++ b/crossbundle/tools/src/commands/android/sign_apk.rs
@@ -1,11 +1,11 @@
 use crate::error::*;
 use crate::tools::*;
-use android_tools::java_tools::AabKey;
+use android_tools::java_tools::Key;
 use std::path::Path;
 
 /// Signs APK with given key.
 /// Uses `apksigner` build tool
-pub fn sign_apk(sdk: &AndroidSdk, apk_path: &Path, key: AabKey) -> Result<std::path::PathBuf> {
+pub fn sign_apk(sdk: &AndroidSdk, apk_path: &Path, key: Key) -> Result<std::path::PathBuf> {
     let mut apksigner = sdk.build_tool(bat!("apksigner"), None)?;
     apksigner
         .arg("sign")

--- a/crossbundle/tools/src/tools/android_ndk.rs
+++ b/crossbundle/tools/src/tools/android_ndk.rs
@@ -323,8 +323,6 @@ impl AndroidNdk {
 
 pub fn ndk_install_path() -> crate::error::Result<String> {
     let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk");
-    #[cfg(target_os = "linux")]
-    let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk-bundle");
     let ndk_ver = std::fs::read_dir(&ndk_path)
         .map_err(|_| Error::PathNotFound(ndk_path.clone()))?
         .filter_map(|path| path.ok())

--- a/crossbundle/tools/src/tools/android_ndk.rs
+++ b/crossbundle/tools/src/tools/android_ndk.rs
@@ -324,7 +324,7 @@ impl AndroidNdk {
 pub fn ndk_install_path() -> crate::error::Result<String> {
     let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk");
     #[cfg(target_os = "linux")]
-    let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk");
+    let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk-bundle");
     let ndk_ver = std::fs::read_dir(&ndk_path)
         .map_err(|_| Error::PathNotFound(ndk_path.clone()))?
         .filter_map(|path| path.ok())

--- a/crossbundle/tools/src/tools/android_ndk.rs
+++ b/crossbundle/tools/src/tools/android_ndk.rs
@@ -323,6 +323,8 @@ impl AndroidNdk {
 
 pub fn ndk_install_path() -> crate::error::Result<String> {
     let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk");
+    #[cfg(target_os = "linux")]
+    let ndk_path = PathBuf::from(android_tools::sdk_install_path()?).join("ndk");
     let ndk_ver = std::fs::read_dir(&ndk_path)
         .map_err(|_| Error::PathNotFound(ndk_path.clone()))?
         .filter_map(|path| path.ok())

--- a/crossbundle/tools/tests/bundletool.rs
+++ b/crossbundle/tools/tests/bundletool.rs
@@ -1,4 +1,4 @@
-use android_tools::java_tools::{android_dir, Key, JarSigner, KeyAlgorithm, Keytool};
+use android_tools::java_tools::{android_dir, JarSigner, Key, KeyAlgorithm, Keytool};
 use crossbundle_tools::{
     commands::android::{extract_archive, gen_minimal_unsigned_aab, gen_zip_modules, remove},
     tools::{AndroidSdk, BuildApks, BuildBundle, GetSizeTotal},

--- a/crossbundle/tools/tests/bundletool.rs
+++ b/crossbundle/tools/tests/bundletool.rs
@@ -1,4 +1,4 @@
-use android_tools::java_tools::{android_dir, AabKey, JarSigner, KeyAlgorithm, Keytool};
+use android_tools::java_tools::{android_dir, Key, JarSigner, KeyAlgorithm, Keytool};
 use crossbundle_tools::{
     commands::android::{extract_archive, gen_minimal_unsigned_aab, gen_zip_modules, remove},
     tools::{AndroidSdk, BuildApks, BuildBundle, GetSizeTotal},
@@ -26,7 +26,7 @@ fn test_build_apks() {
     remove(target).unwrap();
 
     // Creates new keystore to sign aab
-    let aab_key = AabKey::new_default().unwrap();
+    let aab_key = Key::new_default().unwrap();
     Keytool::new()
         .genkeypair(true)
         .v(true)
@@ -84,7 +84,7 @@ fn build_bundle_test() {
     remove(target).unwrap();
 
     // Creates new keystore to sign aab
-    let aab_key = AabKey::new_default().unwrap();
+    let aab_key = Key::new_default().unwrap();
     Keytool::new()
         .genkeypair(true)
         .v(true)

--- a/docs/crossbundle-install-command.md
+++ b/docs/crossbundle-install-command.md
@@ -39,10 +39,10 @@ Also you can install packages manually. To see all available tools use the -h fl
 crossbundle install sdk-manager --list
 ```
 
-And then enter the command. The command will install android-ndk-23 on your PC.
+And then enter the command.
 
 ```sh
-crossbundle install sdk-manager --install "ndk;23.1.7779620"
+crossbundle install sdk-manager --install "build-tools;31.0.0" "ndk;23.1.7779620" "platforms;android-30"
 ```
 
 The command will install packages into `$HOME\AppData\Local\Android\Sdk\` for Windows, `$HOME/Library/Android/sdk/` for macOS, and `$HOME/Android/sdk/` for Linux.


### PR DESCRIPTION
# Objective

Fix Todo marker in crossbundle/cli/commands/install/sdk_manager.rs

## Solution

Use clap derive macros to resolve the problem with multiple passed arguments

## Changelog

Now we can use the command below correctly: 
```sh
crossbundle install sdk-manager --install "<package1>" "<package2>" "<package3>"
```
