### PR TITLE
Update Docker image and add CI test of it

### DIFF
--- a/.github/docker/crossbundle.Dockerfile
+++ b/.github/docker/crossbundle.Dockerfile
@@ -11,8 +11,7 @@ RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager --update
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/23.1.7779620
 
 # Install bundletool
-RUN wget -q https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar \
-    && mv bundletool-all-1.8.2.jar ${ANDROID_SDK_ROOT}/bundletool-all-1.8.2.jar
+RUN wget -q https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar
 ENV BUNDLETOOL_PATH=${ANDROID_SDK_ROOT}/bundletool-all-1.8.2.jar
 
 RUN wget https://services.gradle.org/distributions/gradle-7.4-all.zip \

--- a/.github/docker/crossbundle.Dockerfile
+++ b/.github/docker/crossbundle.Dockerfile
@@ -1,24 +1,13 @@
-FROM eclipse-temurin:11.0.13_8-jdk
+FROM androidsdk/android-30
 LABEL org.opencontainers.image.source https://github.com/dodorare/crossbow
 
 RUN apt update -yq && apt upgrade -yq \
     && apt install -yq curl unzip wget cmake build-essential pkg-config libssl-dev libssl1.1
 
-# Install Android SDK
-ENV ANDROID_SDK_ROOT=/opt/android-sdk-linux
-RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
-    && cd ${ANDROID_SDK_ROOT}/cmdline-tools \
-    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip \
-    && unzip -q commandlinetools-linux-8512546_latest.zip \
-    && rm commandlinetools-linux-8512546_latest.zip \
-    && mv cmdline-tools/ latest/ \
-    && chown -R root:root /opt
+# Install Android NDK
 RUN ulimit -c unlimited
-RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platform-tools"
-RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platforms;android-30"
-RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;31.0.0"
-RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "ndk;23.1.7779620"
-RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --update
+RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager "ndk;23.1.7779620"
+RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager --update
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/23.1.7779620
 
 # Install bundletool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,17 @@ jobs:
         cd ~/example/
         crossbundle build android --apk --release --quad
 
+  build-example-in-docker:
+    name: Build Crossbundle Example from Docker
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Crossbundle image
+      run: docker build -t tmp -f .github/docker/crossbundle.Dockerfile .
+    - name: Build Crossbundle Example
+      run: |
+        docker run --rm -it -v "$(pwd)/:/src" -w /src/examples/macroquad-permissions tmp build android --quad --release
+
   clean:
     name: Check code format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       run: docker build -t tmp -f .github/docker/crossbundle.Dockerfile .
     - name: Build Crossbundle Example
       run: |
-        docker run --rm -it -v "$(pwd)/:/src" -w /src/examples/macroquad-permissions tmp build android --quad --release
+        docker run --rm -v "$(pwd)/:/src" -w /src/examples/macroquad-permissions tmp build android --quad --release
 
   clean:
     name: Check code format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform Rust Toolkit for Games 🏹"
@@ -16,11 +16,11 @@ displaydoc = "0.2"
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-crossbow-android = { path = "platform/android", version = "0.1.6", optional = true }
+crossbow-android = { path = "platform/android", version = "0.1.7", optional = true }
 ndk-glue = "0.6.2"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-crossbow-ios = { path = "platform/ios", version = "0.1.6", optional = true }
+crossbow-ios = { path = "platform/ios", version = "0.1.7", optional = true }
 
 [patch.crates-io]
 winit = { git = "https://github.com/rust-windowing/winit", rev = "f93f2c158bf527ed56ab2b6f5272214f0c1d9f7d" }

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbundle"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Build and publish apps for Android/iOS"
@@ -18,7 +18,7 @@ name = "crossbundle"
 path = "src/main.rs"
 
 [dependencies]
-crossbundle-tools = { path = "../tools", version = "0.1.6" }
+crossbundle-tools = { path = "../tools", version = "0.1.7" }
 android-tools = "0.2.9"
 clap = { version = "3.2.8", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crossbundle/cli/src/commands/install/command_line_tools.rs
+++ b/crossbundle/cli/src/commands/install/command_line_tools.rs
@@ -1,8 +1,8 @@
 use super::*;
-use android_tools::sdk_install_path;
 use clap::Parser;
 use crossbundle_tools::{
     commands::android::{self, remove},
+    tools::AndroidSdk,
     utils::Config,
 };
 use std::path::{Path, PathBuf};
@@ -38,7 +38,8 @@ impl CommandLineToolsInstallCommand {
         )?;
         self.download_and_save_file(command_line_tools_download_url, &file_path)?;
 
-        let sdk_path = sdk_install_path()?;
+        let sdk = AndroidSdk::from_env()?;
+        let sdk_path = sdk.sdk_path();
 
         if let Some(path) = &self.install_path {
             config.status_message(

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbundle-tools"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Build and publish apps for Android/iOS"

--- a/crossbundle/tools/src/tools/android_ndk.rs
+++ b/crossbundle/tools/src/tools/android_ndk.rs
@@ -21,15 +21,29 @@ impl AndroidNdk {
                 .or_else(|| std::env::var("ANDROID_NDK_HOME").ok())
                 .or_else(|| std::env::var("NDK_HOME").ok());
             // Default ndk installation path
-            if ndk_path.is_none()
+            if let Some(ndk_path) = ndk_path {
+                PathBuf::from(ndk_path)
+            } else if ndk_path.is_none()
                 && sdk_path.is_some()
                 && sdk_path.as_ref().unwrap().join("ndk-bundle").exists()
             {
                 sdk_path.unwrap().join("ndk-bundle")
-            } else if let Some(ndk_path) = ndk_path {
-                PathBuf::from(ndk_path)
             } else {
-                PathBuf::from(ndk_install_path()?)
+                let ndk_path = if let Some(sdk_path) = sdk_path {
+                    sdk_path.to_owned()
+                } else {
+                    android_tools::sdk_install_path()?
+                }
+                .join("ndk");
+                let ndk_ver = std::fs::read_dir(&ndk_path)
+                    .map_err(|_| Error::PathNotFound(ndk_path.clone()))?
+                    .filter_map(|path| path.ok())
+                    .filter(|path| path.path().is_dir())
+                    .filter_map(|path| path.file_name().into_string().ok())
+                    .filter(|name| name.chars().next().unwrap().is_ascii_digit())
+                    .max()
+                    .ok_or(AndroidError::AndroidNdkNotFound)?;
+                ndk_path.join(ndk_ver)
             }
         };
         let build_tag = std::fs::read_to_string(ndk_path.join("source.properties"))
@@ -321,18 +335,4 @@ impl AndroidNdk {
         }
         Ok(version_specific_libraries_path)
     }
-}
-
-pub fn ndk_install_path() -> crate::error::Result<String> {
-    let ndk_path = android_tools::sdk_install_path()?.join("ndk");
-    let ndk_ver = std::fs::read_dir(&ndk_path)
-        .map_err(|_| Error::PathNotFound(ndk_path.clone()))?
-        .filter_map(|path| path.ok())
-        .filter(|path| path.path().is_dir())
-        .filter_map(|path| path.file_name().into_string().ok())
-        .filter(|name| name.chars().next().unwrap().is_ascii_digit())
-        .max()
-        .ok_or(AndroidError::AndroidNdkNotFound)?;
-    let ndk_install_path = ndk_path.join(ndk_ver).to_str().unwrap().to_string();
-    Ok(ndk_install_path)
 }

--- a/crossbundle/tools/src/tools/android_sdk.rs
+++ b/crossbundle/tools/src/tools/android_sdk.rs
@@ -21,14 +21,11 @@ impl AndroidSdk {
                 .ok()
                 .or_else(|| std::env::var("ANDROID_SDK_PATH").ok())
                 .or_else(|| std::env::var("ANDROID_HOME").ok());
-            PathBuf::from(
-                sdk_path.unwrap_or(
-                    android_tools::sdk_install_path()?
-                        .to_str()
-                        .unwrap()
-                        .to_string(),
-                ),
-            )
+            if let Some(sdk_path) = sdk_path {
+                PathBuf::from(sdk_path)
+            } else {
+                android_tools::sdk_install_path()?
+            }
         };
         let build_deps_path = sdk_path.join("build-tools");
         let build_deps_version = std::fs::read_dir(&build_deps_path)

--- a/docs/src/install/android-linux.md
+++ b/docs/src/install/android-linux.md
@@ -57,7 +57,18 @@ To prepare to run your `Crossbow` app on an Android device, you need an Android 
 
 ## Set up the Android emulator
 
-To prepare to run and test your Flutter app on the Android emulator, follow these steps:
+To prepare to run and test your Crossbow app on the Android emulator, follow these steps if you want to install it from the console:
+
+```sh
+# Run following command to install System Image for Android SDK 30
+crossbundle install sdk-manager --install "system-images;android-30;google_apis;x86_64"
+# Run this command to create a new emulator
+avdmanager create avd -n Phone -k "system-images;android-30;google_apis;x86_64"
+# And finally run this command to start the emulator
+emulator -avd=Phone
+```
+
+If you want to install it from the GUI, follow these instructions:
 
 1. Enable [`VM acceleration`](https://developer.android.com/studio/run/emulator-acceleration) on your machine.
 2. Launch **Android Studio**, click the **AVD Manager** icon, and select **Create Virtual Device**.

--- a/docs/src/install/android-macos.md
+++ b/docs/src/install/android-macos.md
@@ -57,7 +57,18 @@ To prepare to run your `crossbow` app on an Android device, you need an Android 
 
 ## Set up the Android emulator
 
-To prepare to run and test your Crossbow app on the Android emulator, follow these steps:
+To prepare to run and test your Crossbow app on the Android emulator, follow these steps if you want to install it from the console:
+
+```sh
+# Run following command to install System Image for Android SDK 30
+crossbundle install sdk-manager --install "system-images;android-30;google_apis;x86_64"
+# Run this command to create a new emulator
+avdmanager create avd -n Phone -k "system-images;android-30;google_apis;x86_64"
+# And finally run this command to start the emulator
+emulator -avd=Phone
+```
+
+If you want to install it from the GUI, follow these instructions:
 
 1. Enable [`VM acceleration`](https://developer.android.com/studio/run/emulator-acceleration) on your machine.
 2. Launch **Android Studio**, click the **AVD Manager** icon, and select **Create Virtual Device**.

--- a/docs/src/install/android-windows.md
+++ b/docs/src/install/android-windows.md
@@ -48,7 +48,18 @@ To prepare to run your `Crossbow` app on an Android device, you need an Android 
 
 ## Set up the Android emulator
 
-To prepare to run and test your Crossbow app on the Android emulator, follow these steps:
+To prepare to run and test your Crossbow app on the Android emulator, follow these steps if you want to install it from the console:
+
+```sh
+# Run following command to install System Image for Android SDK 30
+crossbundle install sdk-manager --install "system-images;android-30;google_apis;x86_64"
+# Run this command to create a new emulator
+avdmanager create avd -n Phone -k "system-images;android-30;google_apis;x86_64"
+# And finally run this command to start the emulator
+emulator -avd=Phone
+```
+
+If you want to install it from the GUI, follow these instructions:
 
 1. Enable [`VM acceleration`](https://developer.android.com/studio/run/emulator-acceleration) on your machine.
 2. Launch **Android Studio**, click the **AVD Manager** icon, and select **Create Virtual Device**.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -20,3 +20,9 @@ A lot of functionality was inspired by [Godot](https://github.com/godotengine/go
 * **Simple**: Easy to start but flexible for strong devs.
 * **Capable**: It's possible to build plain **.apk/.aab** or **.app/.ipa**; or with help of *Gradle/XCode*.
 * **Rust**: Don't leave your *Rust* code - **everything** can be configured from `Cargo.toml`.
+
+## Next steps
+
+As the next steps we recommend you to install and setup `crossbundle` to be able to build, test, and run your project!
+
+See [Getting Started](install/README.md) for more information.

--- a/examples/bevy-2d/Cargo.toml
+++ b/examples/bevy-2d/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy-2d"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.6", path = "../../" }
+crossbow = { version = "0.1.7", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 bevy = { version = "0.7.0", features = ["mp3"] }

--- a/examples/bevy-3d/Cargo.toml
+++ b/examples/bevy-3d/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy-3d"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.6", path = "../../" }
+crossbow = { version = "0.1.7", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 bevy = "0.7.0"

--- a/examples/bevy-explorer/Cargo.toml
+++ b/examples/bevy-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-explorer"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 

--- a/examples/macroquad-3d/Cargo.toml
+++ b/examples/macroquad-3d/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "macroquad-3d"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.6", path = "../../" }
+crossbow = { version = "0.1.7", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 macroquad = "0.3.7"

--- a/examples/macroquad-permissions/Cargo.toml
+++ b/examples/macroquad-permissions/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "macroquad-permissions"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["DodoRare Team <support@dodorare.com>"]
 edition = "2021"
 
 [dependencies]
-crossbow = { version = "0.1.6", path = "../../" }
+crossbow = { version = "0.1.7", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
 macroquad = "0.3.7"
 
 [target.'cfg(target_os = "android")'.dependencies]
-crossbow-admob = { version = "0.1.6", path = "../../plugins/admob" }
+crossbow-admob = { version = "0.1.7", path = "../../plugins/admob" }
 
 [package.metadata.android]
 app_name = "Permissions"
@@ -23,7 +23,7 @@ build_targets = ["aarch64-linux-android"]
 assets = "assets"
 res = "res/android"
 
-# plugins_remote = ["com.crossbow.admob:admob:0.1.6"]
+# plugins_remote = ["com.crossbow.admob:admob:0.1.7"]
 
 [[package.metadata.android.plugins_local_projects]]
 include = ":crossbow"

--- a/platform/android/Cargo.toml
+++ b/platform/android/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow-android"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform Rust Toolkit for Games 🏹"

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    crossbowLibrary    : "0.1.6",
+    crossbowLibrary    : "0.1.7",
     androidGradlePlugin: "7.0.0",
     compileSdk         : 31,
     minSdk             : 19,

--- a/platform/ios/Cargo.toml
+++ b/platform/ios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow-ios"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform Rust Toolkit for Games 🏹"

--- a/plugins/admob/Cargo.toml
+++ b/plugins/admob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbow-admob"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "AdMob Plugin for Crossbow"
@@ -10,4 +10,4 @@ keywords = ["crossbow", "google", "admob", "android", "ads"]
 readme = "README.md"
 
 [dependencies]
-crossbow-android = { path = "../../platform/android", version = "0.1.6" }
+crossbow-android = { path = "../../platform/android", version = "0.1.7" }

--- a/plugins/admob/README.md
+++ b/plugins/admob/README.md
@@ -22,15 +22,15 @@ Just add Rust dependencies like this:
 
 ```toml
 [dependencies]
-crossbow = "0.1.6"
-crossbow-admob = "0.1.6"
+crossbow = "0.1.7"
+crossbow-admob = "0.1.7"
 ```
 
 And finally, add this to your Crossbow Android configuration:
 
 ```toml
 [package.metadata.android]
-plugins_remote = ["com.crossbow.admob:admob:0.1.6"]
+plugins_remote = ["com.crossbow.admob:admob:0.1.7"]
 ```
 
 > That's it, now you can start using AdMob ads!

--- a/plugins/admob/android/config.gradle
+++ b/plugins/admob/android/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    crossbowLibrary    : "0.1.6",
+    crossbowLibrary    : "0.1.7",
     androidGradlePlugin: "7.0.0",
     compileSdk         : 31,
     minSdk             : 19,


### PR DESCRIPTION
# Objective

- Current docker image fails on Windows machines.
- It's hard to tell that the docker image is working without actually running it.
- Documentation about Android emulator - lacks the option to install it through cli.

## Solution

- Update `Dockerfile` and extend [android-sdk docker image](https://github.com/docker-android-sdk/android-30).
- Add CI to test Android build inside Docker image.
- Update documentation.
- Fixes issues with Android SDK resolution.

## Changelog

**Important**: This change bumps all libraries' versions to 0.1.7.
