### PR TITLE
Fix crossbundle install preferred flag

### DIFF
--- a/crossbundle/cli/src/commands/install/bundletool.rs
+++ b/crossbundle/cli/src/commands/install/bundletool.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::error::Result;
 use clap::Parser;
 use crossbundle_tools::types::Config;
 use std::path::PathBuf;
@@ -23,7 +24,7 @@ pub struct BundletoolInstallCommand {
 
 impl BundletoolInstallCommand {
     /// Download and install bundletool to provided or default path
-    pub fn install(&self, config: &Config) -> crate::error::Result<()> {
+    pub fn install(&self, config: &Config) -> Result<()> {
         let home_dir = default_file_path(self.file_name())?
             .parent()
             .unwrap()
@@ -32,7 +33,7 @@ impl BundletoolInstallCommand {
             for bundletool in std::fs::read_dir(&home_dir)? {
                 let installed_bundletool = bundletool?.path();
                 if installed_bundletool.ends_with(self.file_name()) {
-                    config.status("You have installed budletool on your system already. Use `--force` command to overwrite.")?;
+                    config.status("You have installed bundletool on your system already. Use `--force` command to overwrite.")?;
                     return Ok(());
                 }
             }

--- a/crossbundle/cli/src/commands/install/command_line_tools.rs
+++ b/crossbundle/cli/src/commands/install/command_line_tools.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::error::Result;
 use android_tools::sdk_install_path;
 use clap::Parser;
 use crossbundle_tools::{commands::android::*, types::Config};
@@ -26,7 +27,11 @@ pub struct CommandLineToolsInstallCommand {
 impl CommandLineToolsInstallCommand {
     /// Download command line tools zip archive and extract it in specified sdk root
     /// directory
-    pub fn install(&self, config: &Config) -> crate::error::Result<()> {
+    pub fn install(&self, config: &Config) -> Result<()> {
+        let cmdline_tools_path = android_tools::sdk_install_path()?.join("cmdline-tools");
+        if cmdline_tools_path.exists() {
+            return Ok(());
+        }
         if self.force {
             remove(vec![default_file_path(self.file_name())?])?;
         }
@@ -60,7 +65,7 @@ impl CommandLineToolsInstallCommand {
             extract_archive(&file_path, Path::new(&sdk_path))?;
         }
 
-        config.status("Deleting zip archive thaw was left after installation")?;
+        config.status("Deleting zip archive that was left after installation")?;
         remove(vec![file_path])?;
         Ok(())
     }
@@ -72,11 +77,7 @@ impl CommandLineToolsInstallCommand {
 
     /// Check home directory for zip file. If it doesn't exists download zip file and save
     /// it in the directory
-    pub fn download_and_save_file(
-        &self,
-        download_url: PathBuf,
-        file_path: &Path,
-    ) -> crate::error::Result<()> {
+    pub fn download_and_save_file(&self, download_url: PathBuf, file_path: &Path) -> Result<()> {
         remove(vec![file_path.to_path_buf()])?;
         for dir in std::fs::read_dir(file_path.parent().unwrap())? {
             let zip_path = dir?.path();

--- a/crossbundle/cli/src/commands/install/sdkmanager.rs
+++ b/crossbundle/cli/src/commands/install/sdkmanager.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use crossbundle_tools::{
     error::{CommandExt, Result},
-    types::Config,
+    types::{Config, android_sdk_path},
     EXECUTABLE_SUFFIX_BAT,
 };
 use std::path::Path;
@@ -164,7 +164,7 @@ impl SdkManagerInstallCommand {
 
     /// Run sdkmanager command with specified flags and options
     pub fn run(&self, _config: &Config) -> Result<()> {
-        let sdk_path = android_tools::sdk_install_path()?;
+        let sdk_path = android_sdk_path()?;
         // Android Studio installs cmdline-tools into
         // $ANDROID_SDK_ROOT/cmdline-tools/<version>/bin. Crossbundle install command
         // ignores <version> directory so we need convert cmd-line-tools path to Option<T> to

--- a/crossbundle/cli/src/commands/install/sdkmanager.rs
+++ b/crossbundle/cli/src/commands/install/sdkmanager.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use crossbundle_tools::{
     error::{CommandExt, Result},
-    types::{Config, android_sdk_path},
+    types::{android_sdk_path, Config},
     EXECUTABLE_SUFFIX_BAT,
 };
 use std::path::Path;

--- a/crossbundle/cli/src/commands/install/sdkmanager.rs
+++ b/crossbundle/cli/src/commands/install/sdkmanager.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use crossbundle_tools::{
-    error::CommandExt, types::AndroidSdk, types::Config, EXECUTABLE_SUFFIX_BAT,
+    error::{CommandExt, Result},
+    types::Config,
+    EXECUTABLE_SUFFIX_BAT,
 };
 use std::path::Path;
 
@@ -161,9 +163,8 @@ impl SdkManagerInstallCommand {
     }
 
     /// Run sdkmanager command with specified flags and options
-    pub fn run(&self, _config: &Config) -> crate::error::Result<()> {
-        let sdk = AndroidSdk::from_env()?;
-        let sdk_path = sdk.sdk_path();
+    pub fn run(&self, _config: &Config) -> Result<()> {
+        let sdk_path = android_tools::sdk_install_path()?;
         // Android Studio installs cmdline-tools into
         // $ANDROID_SDK_ROOT/cmdline-tools/<version>/bin. Crossbundle install command
         // ignores <version> directory so we need convert cmd-line-tools path to Option<T> to
@@ -186,11 +187,7 @@ impl SdkManagerInstallCommand {
         Ok(())
     }
 
-    pub fn sdkmanager_command(
-        &self,
-        sdkmanager_path: &Path,
-        sdk_root: &Path,
-    ) -> crate::error::Result<()> {
+    pub fn sdkmanager_command(&self, sdkmanager_path: &Path, sdk_root: &Path) -> Result<()> {
         let mut sdkmanager = std::process::Command::new(sdkmanager_path);
         if let Some(sdk_root) = &self.sdk_root {
             sdkmanager.arg(sdk_root);

--- a/crossbundle/tools/src/types/android/android_sdk.rs
+++ b/crossbundle/tools/src/types/android/android_sdk.rs
@@ -16,17 +16,7 @@ pub struct AndroidSdk {
 impl AndroidSdk {
     /// Using environment variables tools
     pub fn from_env() -> Result<Self> {
-        let sdk_path = {
-            let sdk_path = std::env::var("ANDROID_SDK_ROOT")
-                .ok()
-                .or_else(|| std::env::var("ANDROID_SDK_PATH").ok())
-                .or_else(|| std::env::var("ANDROID_HOME").ok());
-            if let Some(sdk_path) = sdk_path {
-                PathBuf::from(sdk_path)
-            } else {
-                android_tools::sdk_install_path()?
-            }
-        };
+        let sdk_path = android_sdk_path()?;
         let build_deps_path = sdk_path.join("build-tools");
         let build_deps_version = std::fs::read_dir(&build_deps_path)
             .map_err(|_| Error::PathNotFound(build_deps_path.clone()))?
@@ -137,4 +127,20 @@ impl AndroidSdk {
         }
         Ok(android_jar)
     }
+}
+
+/// Get path to android sdk
+pub fn android_sdk_path() -> Result<PathBuf> {
+    let sdk_path = {
+        let sdk_path = std::env::var("ANDROID_SDK_ROOT")
+            .ok()
+            .or_else(|| std::env::var("ANDROID_SDK_PATH").ok())
+            .or_else(|| std::env::var("ANDROID_HOME").ok());
+        if let Some(sdk_path) = sdk_path {
+            PathBuf::from(sdk_path)
+        } else {
+            android_tools::sdk_install_path()?
+        }
+    };
+    Ok(sdk_path)
 }


### PR DESCRIPTION
# Objective

Fix `crossbundle install --preferred` command work.

## Solution

Use another function from android-tools-rs crate to get Android SDK root path. 
