### PR TITLE
Fix subxt example

### DIFF
--- a/examples/bevy-explorer/Cargo.toml
+++ b/examples/bevy-explorer/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 crossbow = { version = "0.2.3", path = "../../" }
 log = "0.4"
 anyhow = "1.0"
-subxt = "0.21"
+subxt = "0.23.0"
 tokio = { version = "1.17", features = ["sync", "macros", "rt-multi-thread"] }
 bevy = { version = "0.8.1", default-features = false, features = ["bevy_winit", "render", "bevy_asset"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
-jsonrpsee = { version = "0.10.1", features = ["async-client", "client-ws-transport"] }
+jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport"] }
 
 [package.metadata]
 app_name = "Bevy Explorer"
@@ -26,12 +26,16 @@ resources = ["../../assets/res/android"]
 include = ":crossbow"
 dont_implement = true
 project_dir = "../../platform/android/java"
+
 [[package.metadata.android.plugins_local_projects]]
 include = ":crossbow:lib"
+
 [package.metadata.android.manifest]
 package = "com.crossbow.example.permissions"
+
 [[package.metadata.android.manifest.uses_permission]]
 name = "android.permission.INTERNET"
+
 [package.metadata.android.manifest.uses_sdk]
 min_sdk_version = 19
 target_sdk_version = 31

--- a/examples/bevy-explorer/src/explorer.rs
+++ b/examples/bevy-explorer/src/explorer.rs
@@ -159,7 +159,13 @@ pub fn explorer_text_updater(
 }
 
 pub fn explorer_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font_handle: Handle<Font> = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font_path = std::path::PathBuf::from("assets")
+        .join("fonts")
+        .join("FiraSans-Bold.ttf");
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let assets_path = manifest_dir.parent().unwrap().parent().unwrap();
+    println!("assets {}", assets_path.display());
+    let font_handle: Handle<Font> = asset_server.load(assets_path.join(font_path));
     commands.spawn_bundle(Camera2dBundle::default());
     // Root node (padding)
     commands

--- a/examples/bevy-explorer/src/explorer.rs
+++ b/examples/bevy-explorer/src/explorer.rs
@@ -335,7 +335,8 @@ pub fn explorer_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-/// Workaround. Failed to get assets on windows from the .load() method through the relative path to asset
+/// Workaround. Failed to get assets on windows from the .load() method through the
+/// relative path to asset
 fn get_assets_path(asset_server: Res<AssetServer>) -> Handle<Font> {
     let font_path = std::path::PathBuf::from("assets")
         .join("fonts")

--- a/examples/bevy-explorer/src/explorer.rs
+++ b/examples/bevy-explorer/src/explorer.rs
@@ -159,13 +159,10 @@ pub fn explorer_text_updater(
 }
 
 pub fn explorer_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font_path = std::path::PathBuf::from("assets")
-        .join("fonts")
-        .join("FiraSans-Bold.ttf");
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let assets_path = manifest_dir.parent().unwrap().parent().unwrap();
-    println!("assets {}", assets_path.display());
-    let font_handle: Handle<Font> = asset_server.load(assets_path.join(font_path));
+    #[cfg(target_os = "windows")]
+    let font_handle: Handle<Font> = get_assets_path(asset_server).unwrap();
+    #[cfg(not(target_os = "windows"))]
+    let font_handle: Handle<Font> = asset_server.load("fonts/FiraSans-Bold.ttf");
     commands.spawn_bundle(Camera2dBundle::default());
     // Root node (padding)
     commands
@@ -341,4 +338,15 @@ pub fn explorer_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                         });
                 });
         });
+}
+
+/// Workaround. Failed to get assets on windows from the .load() method through the relative path to asset
+fn get_assets_path(asset_server: Res<AssetServer>) -> Result<Handle<Font>, anyhow::Error> {
+    let font_path = std::path::PathBuf::from("assets")
+        .join("fonts")
+        .join("FiraSans-Bold.ttf");
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let assets_path = manifest_dir.parent().unwrap().parent().unwrap();
+    let font_handle: Handle<Font> = asset_server.load(assets_path.join(font_path));
+    Ok(font_handle)
 }


### PR DESCRIPTION
# Objective

Fix bevy-explorer example 

## Solution

Bump `subxt` crate version to `0.23.0`. Add some workaround that fixes a problem with getting assets and bevy TaskPool panics. 
