### PR TITLE
Migrate workspace to Rust 2024

### DIFF
--- a/.github/docker/crossbundle.Dockerfile
+++ b/.github/docker/crossbundle.Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 RUN --mount=type=cache,id=crossbundle-registry,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,id=crossbundle-target-${TARGETARCH},target=/build/target,sharing=locked \
     CARGO_TARGET_DIR=/build/target \
-    cargo install --path crossbundle/cli --locked --root /opt/crossbundle
+    cargo "+${RUST_VERSION}" install --path crossbundle/cli --locked --root /opt/crossbundle
 
 
 FROM ubuntu:24.04

--- a/.github/workflows/latest-dependencies.yml
+++ b/.github/workflows/latest-dependencies.yml
@@ -90,7 +90,7 @@ jobs:
           --locked --no-fail-fast
       - name: Save the generated lockfile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: latest-compatible-Cargo.lock
           path: Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,12 +1953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,19 +2392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
- "objc",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,7 +2576,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -2608,17 +2589,6 @@ checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -2765,12 +2735,9 @@ name = "crossbow-ios"
 version = "0.2.3"
 dependencies = [
  "anyhow",
- "block",
- "cocoa-foundation",
- "core-foundation 0.10.1",
+ "block2 0.6.2",
  "displaydoc",
- "libc",
- "objc",
+ "objc2 0.6.4",
  "thiserror 2.0.20",
 ]
 
@@ -6102,15 +6069,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ apple-bundle = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = { workspace = true }
-crossbow-android = { workspace = true, optional = true }
+crossbow-android = { workspace = true, default-features = true, optional = true }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 crossbow-ios = { workspace = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,69 @@
+[workspace]
+resolver = "3"
+members = [
+    "plugins/*",
+    "crossbundle/*",
+    "platform/*",
+    "examples/*",
+]
+
+[workspace.package]
+edition = "2024"
+
+[workspace.dependencies]
+admob-android = { path = "plugins/admob-android", version = "0.2.3" }
+android-manifest = "0.3.0"
+android-tools = "0.2.11"
+anyhow = "1.0"
+apple-bundle = "0.2.1"
+async-channel = "2.5"
+atty = "0.2"
+bevy = { version = "0.19.0", default-features = false }
+block2 = "0.6.2"
+cargo = "0.98"
+cargo-util = "0.2"
+clap = "4.6"
+colored = "3.1"
+crossbow = { path = ".", version = "0.2.3", default-features = false }
+crossbow-android = { path = "platform/android", version = "0.2.3", default-features = false }
+crossbow-ios = { path = "platform/ios", version = "0.2.3" }
+crossbundle-tools = { path = "crossbundle/tools", version = "0.2.3", default-features = false }
+dirs = "6.0"
+displaydoc = "0.2"
+dunce = "1.0"
+fs_extra = "1.3"
+fwdansi = "1.1"
+image = { version = "0.25.10", default-features = false }
+itertools = "0.15"
+jni = "0.22"
+lazy_static = "1.5"
+libc = "0.2"
+log = "0.4"
+macroquad = "0.4.16"
+ndk-context = "0.1"
+ndk-glue = "0.7.0"
+objc2 = "0.6.4"
+play-billing = { path = "plugins/play-billing", version = "0.2.3" }
+play-core = { path = "plugins/play-core", version = "0.2.3" }
+play-games-services = { path = "plugins/play-games-services", version = "0.2.3" }
+pretty_env_logger = "0.5"
+rust-embed = "8.12.0"
+serde = "1.0"
+serde_plain = "1.0"
+simctl = { version = "0.1.1", package = "creator-simctl" }
+tempfile = "3.27"
+termcolor = "1.4"
+thiserror = "2.0"
+ureq = "3.4"
+which = "8.0"
+winapi = "0.3"
+zip = { version = "8.6.0", default-features = false }
+zip-extensions = { version = "0.14.1", default-features = false }
+
 [package]
 name = "crossbow"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform build tools and toolkit for games"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,31 +73,23 @@ readme = "README.md"
 exclude = ["assets/", "docs/"]
 
 [dependencies]
-thiserror = "2.0"
-displaydoc = "0.2"
-anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+thiserror = { workspace = true }
+displaydoc = { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
-android-manifest = { version = "0.3.0", optional = true }
-apple-bundle = { version = "0.2.1", optional = true }
+android-manifest = { workspace = true, optional = true }
+apple-bundle = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "0.7.0"
-crossbow-android = { path = "platform/android", version = "0.2.3", optional = true }
+ndk-glue = { workspace = true }
+crossbow-android = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-crossbow-ios = { path = "platform/ios", version = "0.2.3", optional = true }
+crossbow-ios = { workspace = true, optional = true }
 
 [features]
 default = ["android", "ios"]
 android = ["crossbow-android"]
 ios = ["crossbow-ios"]
 update-manifest = ["apple-bundle", "android-manifest"]
-
-[workspace]
-members = [
-    "plugins/*",
-    "crossbundle/*",
-    "platform/*",
-    "examples/*",
-]

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossbundle"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Build and publish apps for Android/iOS"
 repository = "https://github.com/dodorare/crossbow"
@@ -18,28 +18,28 @@ name = "crossbundle"
 path = "src/main.rs"
 
 [dependencies]
-crossbow = { path = "../../", version = "0.2.3", default-features = false, features = ["update-manifest"] }
-crossbundle-tools = { path = "../tools", version = "0.2.3", default-features = false }
-android-tools = { version = "0.2.11", optional = true }
-clap = { version = "4.6", features = ["derive"] }
-serde = { version = "1.0", features = ["derive"] }
+crossbow = { workspace = true, default-features = false, features = ["update-manifest"] }
+crossbundle-tools = { workspace = true, default-features = false }
+android-tools = { workspace = true, optional = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 
-anyhow = "1.0"
-thiserror = "2.0"
-colored = "3.1"
-displaydoc = "0.2"
-pretty_env_logger = "0.5"
-log = "0.4"
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+colored = { workspace = true }
+displaydoc = { workspace = true }
+pretty_env_logger = { workspace = true }
+log = { workspace = true }
 
-fs_extra = "1.3"
-dirs = "6.0"
-dunce = "1.0"
-ureq = "3.4"
-cargo = "0.98"
-cargo-util = "0.2"
+fs_extra = { workspace = true }
+dirs = { workspace = true }
+dunce = { workspace = true }
+ureq = { workspace = true }
+cargo = { workspace = true }
+cargo-util = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.27"
+tempfile = { workspace = true }
 
 [features]
 default = ["android", "apple"]

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -62,11 +62,12 @@ impl AndroidBuildCommand {
                 self.execute_aab(config, &context)?;
             }
             AndroidStrategy::GradleApk => {
-                let (_, _, gradle_project_path) =
+                let (_, sdk, gradle_project_path) =
                     self.build_gradle(config, &context, &self.export_path)?;
                 config.status("Building Gradle project")?;
                 let mut gradle = gradle_init()?;
                 gradle
+                    .env("ANDROID_SDK_ROOT", sdk.sdk_path())
                     .arg("build")
                     .arg("-p")
                     .arg(dunce::simplified(&gradle_project_path));
@@ -94,11 +95,6 @@ impl AndroidBuildCommand {
         } else {
             target_dir.join("android").join(&package_name)
         };
-
-        // Set ANDROID_SDK_ROOT if there's no one
-        if std::env::var("ANDROID_SDK_ROOT").is_err() {
-            std::env::set_var("ANDROID_SDK_ROOT", sdk.sdk_path());
-        }
 
         config.status("Preparing resources and assets")?;
         let (assets, resources) =

--- a/crossbundle/cli/src/commands/install/command_line_tools.rs
+++ b/crossbundle/cli/src/commands/install/command_line_tools.rs
@@ -3,7 +3,7 @@ use crate::error::Result;
 use clap::Parser;
 use crossbundle_tools::{
     commands::android::*,
-    types::{android_sdk_path, Config},
+    types::{Config, android_sdk_path},
 };
 use std::path::{Path, PathBuf};
 

--- a/crossbundle/cli/src/commands/install/sdkmanager.rs
+++ b/crossbundle/cli/src/commands/install/sdkmanager.rs
@@ -1,8 +1,8 @@
 use clap::{ArgAction, Parser};
 use crossbundle_tools::{
-    error::{CommandExt, Result},
-    types::{android_sdk_path, Config},
     EXECUTABLE_SUFFIX_BAT,
+    error::{CommandExt, Result},
+    types::{Config, android_sdk_path},
 };
 use std::path::Path;
 

--- a/crossbundle/cli/src/commands/run/android.rs
+++ b/crossbundle/cli/src/commands/run/android.rs
@@ -1,4 +1,4 @@
-use crate::commands::build::{android::AndroidBuildCommand, BuildContext};
+use crate::commands::build::{BuildContext, android::AndroidBuildCommand};
 use crate::error::*;
 use clap::Parser;
 use crossbundle_tools::{

--- a/crossbundle/cli/src/commands/run/apple.rs
+++ b/crossbundle/cli/src/commands/run/apple.rs
@@ -1,4 +1,4 @@
-use crate::commands::build::{apple::IosBuildCommand, BuildContext};
+use crate::commands::build::{BuildContext, apple::IosBuildCommand};
 use crate::error::*;
 use clap::Parser;
 use crossbundle_tools::{commands::apple, types::Config, types::*};

--- a/crossbundle/cli/src/types/android_config.rs
+++ b/crossbundle/cli/src/types/android_config.rs
@@ -1,6 +1,6 @@
 use crossbundle_tools::{
     commands::android::*,
-    types::{android_manifest::AndroidManifest, AndroidTarget, AppWrapper},
+    types::{AndroidTarget, AppWrapper, android_manifest::AndroidManifest},
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/crossbundle/cli/src/types/apple_config.rs
+++ b/crossbundle/cli/src/types/apple_config.rs
@@ -1,4 +1,4 @@
-use crossbundle_tools::types::{apple_bundle::prelude::*, IosTarget};
+use crossbundle_tools::types::{IosTarget, apple_bundle::prelude::*};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 

--- a/crossbundle/cli/tests/build_gradle.rs
+++ b/crossbundle/cli/tests/build_gradle.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "android")]
 
-use crossbundle_lib::commands::build::{android::AndroidBuildCommand, BuildContext};
+use crossbundle_lib::commands::build::{BuildContext, android::AndroidBuildCommand};
 use crossbundle_tools::{
     commands::gen_minimal_project,
     types::{AndroidStrategy, AndroidTarget, Config, Shell},

--- a/crossbundle/cli/tests/cargo_metadata.rs
+++ b/crossbundle/cli/tests/cargo_metadata.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "android")]
 
-use crossbundle_lib::commands::build::{android::AndroidBuildCommand, BuildContext};
+use crossbundle_lib::commands::build::{BuildContext, android::AndroidBuildCommand};
 use crossbundle_tools::{
     commands::gen_minimal_project,
-    types::{android_manifest::from_str, AndroidStrategy, AndroidTarget, Config, Shell},
+    types::{AndroidStrategy, AndroidTarget, Config, Shell, android_manifest::from_str},
 };
 
 #[test]

--- a/crossbundle/cli/tests/execute_aab.rs
+++ b/crossbundle/cli/tests/execute_aab.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "android")]
 
-use crossbundle_lib::commands::build::{android::AndroidBuildCommand, BuildContext};
+use crossbundle_lib::commands::build::{BuildContext, android::AndroidBuildCommand};
 use crossbundle_tools::{
     commands::gen_minimal_project,
     types::{AndroidStrategy, AndroidTarget, Config, Shell},

--- a/crossbundle/cli/tests/execute_apk.rs
+++ b/crossbundle/cli/tests/execute_apk.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "android")]
 
-use crossbundle_lib::commands::build::{android::AndroidBuildCommand, BuildContext};
+use crossbundle_lib::commands::build::{BuildContext, android::AndroidBuildCommand};
 use crossbundle_tools::{
     commands::gen_minimal_project,
     types::{AndroidStrategy, AndroidTarget, Config, Shell},

--- a/crossbundle/cli/tests/update_command.rs
+++ b/crossbundle/cli/tests/update_command.rs
@@ -24,10 +24,10 @@ fn test_new_version_released() {
     assert!(!same_version);
 
     let latest = Some(version_string);
-    if let Some(value) = latest {
-        if is_newer_found(&value) {
-            print_new_version_available(&value, &config).unwrap();
-        }
+    if let Some(value) = latest
+        && is_newer_found(&value)
+    {
+        print_new_version_available(&value, &config).unwrap();
     }
 }
 
@@ -50,9 +50,9 @@ fn test_latest_version_is_using() {
     assert!(!newer_version);
 
     let latest = Some(version_string);
-    if let Some(value) = latest {
-        if is_same_found(&value) {
-            print_latest_version_using(&value, &config).unwrap();
-        }
+    if let Some(value) = latest
+        && is_same_found(&value)
+    {
+        print_latest_version_using(&value, &config).unwrap();
     }
 }

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossbundle-tools"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Build and publish apps for Android/iOS"
 repository = "https://github.com/dodorare/crossbow"
@@ -10,45 +10,45 @@ keywords = ["android", "ios"]
 readme = "README.md"
 
 [dependencies]
-crossbow-android = { version = "0.2.3", path = "../../platform/android", default-features = false, features = ["embed"] }
+crossbow-android = { workspace = true, default-features = false, features = ["embed"] }
 # Apple crates
-apple-bundle = { version = "0.2.1", optional = true }
-simctl = { version = "0.1.1", package = "creator-simctl", optional = true }
+apple-bundle = { workspace = true, optional = true }
+simctl = { workspace = true, optional = true }
 # Android crates
-android-manifest = { version = "0.3.0", optional = true }
-android-tools = { version = "0.2.11", optional = true }
+android-manifest = { workspace = true, optional = true }
+android-tools = { workspace = true, optional = true }
 
-serde = { version = "1.0", features = ["derive"] }
-serde_plain = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_plain = { workspace = true }
 
-dunce = "1.0"
-fs_extra = "1.3"
-dirs = "6.0"
-which = "8.0"
-tempfile = "3.27"
-zip = { version = "8.6.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
-zip-extensions = { version = "0.14.1", default-features = false }
-image = { version = "0.25.10", default-features = false, features = ["png", "jpeg"] }
+dunce = { workspace = true }
+fs_extra = { workspace = true }
+dirs = { workspace = true }
+which = { workspace = true }
+tempfile = { workspace = true }
+zip = { workspace = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
+zip-extensions = { workspace = true, default-features = false }
+image = { workspace = true, default-features = false, features = ["png", "jpeg"] }
 
-itertools = "0.15"
-cargo = "0.98"
-cargo-util = "0.2"
+itertools = { workspace = true }
+cargo = { workspace = true }
+cargo-util = { workspace = true }
 
-thiserror = "2.0"
-anyhow = "1.0"
-displaydoc = "0.2"
-log = "0.4"
-termcolor = "1.4"
-atty = "0.2"
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+displaydoc = { workspace = true }
+log = { workspace = true }
+termcolor = { workspace = true }
+atty = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-fwdansi = "1.1"
+fwdansi = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
+workspace = true
 features = [
   "basetsd",
   "handleapi",

--- a/crossbundle/tools/src/commands/android/common/gen_mipmap_res.rs
+++ b/crossbundle/tools/src/commands/android/common/gen_mipmap_res.rs
@@ -123,10 +123,12 @@ mod tests {
             force: false,
         };
         image_generation.gen_mipmap_res_from_icon().unwrap();
-        assert!(res_dir_path
-            .join("res")
-            .join("mipmap-hdpi")
-            .join("ic_launcher.png")
-            .exists())
+        assert!(
+            res_dir_path
+                .join("res")
+                .join("mipmap-hdpi")
+                .join("ic_launcher.png")
+                .exists()
+        )
     }
 }

--- a/crossbundle/tools/src/commands/android/common/rust_compile/cmake_toolchain.rs
+++ b/crossbundle/tools/src/commands/android/common/rust_compile/cmake_toolchain.rs
@@ -1,13 +1,13 @@
 use crate::types::*;
 use std::io::Write;
 
-/// Sets needed environment variables
-pub fn set_cmake_vars(
+/// Returns the environment variables needed by CMake build scripts.
+pub fn cmake_env(
     build_target: crate::types::AndroidTarget,
     ndk: &AndroidNdk,
     target_sdk_version: u32,
     build_target_dir: &std::path::Path,
-) -> cargo::CargoResult<()> {
+) -> cargo::CargoResult<Vec<(String, std::ffi::OsString)>> {
     // Return path to toolchain cmake file
     let cmake_toolchain_path = write_cmake_toolchain(
         target_sdk_version,
@@ -16,11 +16,20 @@ pub fn set_cmake_vars(
         build_target,
     )?;
 
-    // Set cmake environment variables
-    std::env::set_var("CMAKE_TOOLCHAIN_FILE", cmake_toolchain_path);
-    std::env::set_var("CMAKE_GENERATOR", r#"Unix Makefiles"#);
-    std::env::set_var("CMAKE_MAKE_PROGRAM", make_path(ndk.ndk_path()));
-    Ok(())
+    Ok(vec![
+        (
+            "CMAKE_TOOLCHAIN_FILE".to_owned(),
+            cmake_toolchain_path.into_os_string(),
+        ),
+        (
+            "CMAKE_GENERATOR".to_owned(),
+            std::ffi::OsString::from("Unix Makefiles"),
+        ),
+        (
+            "CMAKE_MAKE_PROGRAM".to_owned(),
+            make_path(ndk.ndk_path()).into_os_string(),
+        ),
+    ])
 }
 
 /// Returns path to NDK provided make

--- a/crossbundle/tools/src/commands/android/common/rust_compile/compile_options.rs
+++ b/crossbundle/tools/src/commands/android/common/rust_compile/compile_options.rs
@@ -2,9 +2,9 @@ use crate::error::*;
 use crate::types::*;
 use cargo::{
     core::{
+        Workspace,
         compiler::{CompileKind, CompileTarget, UserIntent},
         resolver::CliFeatures,
-        Workspace,
     },
     ops::CompileOptions,
 };

--- a/crossbundle/tools/src/commands/android/common/rust_compile/consts.rs
+++ b/crossbundle/tools/src/commands/android/common/rust_compile/consts.rs
@@ -11,47 +11,51 @@ pub const HOST_TAG: &str = "linux-x86_64";
 pub const HOST_TAG: &str = "darwin-x86_64";
 
 pub const NDK_GLUE_EXTRA_CODE: &str = r#"
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(target_os = "android")]
 unsafe extern "C" fn ANativeActivity_onCreate(
     activity: *mut std::os::raw::c_void,
     saved_state: *mut std::os::raw::c_void,
     saved_state_size: usize,
 ) {
-    crossbow::ndk_glue::init(
-        activity as _,
-        saved_state as _,
-        saved_state_size as _,
-        main,
-    );
+    unsafe {
+        crossbow::ndk_glue::init(
+            activity as _,
+            saved_state as _,
+            saved_state_size as _,
+            main,
+        );
+    }
 }
 "#;
 
 pub const QUAD_EXTRA_CODE: &str = r##"
 mod cargo_apk_glue_code {
-    extern "C" {
+    unsafe extern "C" {
         pub fn sapp_ANativeActivity_onCreate(
             activity: *mut std::ffi::c_void,
             saved_state: *mut std::ffi::c_void,
             saved_state_size: usize,
         );
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn ANativeActivity_onCreate(
         activity: *mut std::ffi::c_void,
         saved_state: *mut std::ffi::c_void,
         saved_state_size: usize,
     ) {
-        crossbow::ndk_glue::init(
-            activity as _,
-            saved_state as _,
-            saved_state_size as _,
-            super::main,
-        );
-        // TODO: Fix initialization of the ndk_glue crate in sapp
-        sapp_ANativeActivity_onCreate(activity, saved_state, saved_state_size as _);
+        unsafe {
+            crossbow::ndk_glue::init(
+                activity as _,
+                saved_state as _,
+                saved_state_size as _,
+                super::main,
+            );
+            // TODO: Fix initialization of the ndk_glue crate in sapp
+            sapp_ANativeActivity_onCreate(activity, saved_state, saved_state_size as _);
+        }
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sokol_main() {
         let _ = super::main();
     }
@@ -59,6 +63,6 @@ mod cargo_apk_glue_code {
     #[link(name = "log")]
     #[link(name = "EGL")]
     #[link(name = "GLESv3")]
-    extern "C" {}
+    unsafe extern "C" {}
 }
 "##;

--- a/crossbundle/tools/src/commands/android/common/rust_compile/rust_compiler.rs
+++ b/crossbundle/tools/src/commands/android/common/rust_compile/rust_compiler.rs
@@ -14,34 +14,44 @@ pub fn rust_compile(
     lib_name: &str,
     app_wrapper: AppWrapper,
 ) -> Result<()> {
-    configure_rustc()?;
-
     // Specify path to workspace
     let rust_triple = build_target.rust_triple();
 
-    // Set environment variables needed for use with the cc crate
+    // Configure the tools inherited by Cargo and its build-script subprocesses without
+    // mutating the process-global environment. Environment mutation is unsafe in Rust 2024
+    // because other threads may be reading it concurrently.
     let (clang, clang_pp) = ndk.clang(build_target, target_sdk_version)?;
-    std::env::set_var(format!("CC_{}", rust_triple), &clang);
-    std::env::set_var(format!("CXX_{}", rust_triple), clang_pp);
-    std::env::set_var(cargo_env_target_cfg("LINKER", rust_triple), &clang);
     let ar = ndk.toolchain_bin("ar", build_target)?;
-    std::env::set_var(format!("AR_{}", rust_triple), ar);
 
-    let cargo_context = cargo::util::GlobalContext::default()?;
-    let workspace = cargo::core::Workspace::new(&project_path.join("Cargo.toml"), &cargo_context)?;
-
-    // Define directory to build project
-    let build_target_dir = workspace
-        .root()
+    // Resolve the workspace before creating the configured Cargo context so the generated CMake
+    // toolchain is placed in the same target directory as the embedded build.
+    let build_target_dir = workspace_root(project_path)?
         .join("target")
         .join(rust_triple)
         .join(profile);
     std::fs::create_dir_all(&build_target_dir).unwrap();
 
-    set_cmake_vars(build_target, ndk, target_sdk_version, &build_target_dir)?;
+    let mut build_script_env = vec![
+        (format!("CC_{rust_triple}"), clang.clone().into_os_string()),
+        (format!("CXX_{rust_triple}"), clang_pp.into_os_string()),
+        (format!("AR_{rust_triple}"), ar.into_os_string()),
+        ("CXXSTDLIB".to_owned(), "c++".into()),
+    ];
+    build_script_env.extend(cmake_env(
+        build_target,
+        ndk,
+        target_sdk_version,
+        &build_target_dir,
+    )?);
 
-    // Use libc++. It is current default C++ runtime
-    std::env::set_var("CXXSTDLIB", "c++");
+    let mut cargo_context = cargo::util::GlobalContext::default()?;
+    configure_cargo(
+        &mut cargo_context,
+        rust_triple,
+        clang.as_os_str(),
+        &build_script_env,
+    )?;
+    let workspace = cargo::core::Workspace::new(&project_path.join("Cargo.toml"), &cargo_context)?;
 
     // Configure compilation options so that we will build the desired build_target
     let opts = compile_options::compile_options(
@@ -119,11 +129,7 @@ impl cargo::core::compiler::Executor for SharedLibraryExecutor {
             let filename = path.file_name().unwrap().to_owned();
             let source_arg = new_args.iter_mut().find_map(|arg| {
                 let tmp = std::path::Path::new(&arg).file_name().unwrap();
-                if filename == tmp {
-                    Some(arg)
-                } else {
-                    None
-                }
+                if filename == tmp { Some(arg) } else { None }
             });
 
             if let Some(source_arg) = source_arg {
@@ -197,10 +203,11 @@ impl cargo::core::compiler::Executor for SharedLibraryExecutor {
             // Change crate-type from cdylib to rlib
             let mut iter = new_args.iter_mut().rev().peekable();
             while let Some(arg) = iter.next() {
-                if let Some(prev_arg) = iter.peek() {
-                    if *prev_arg == "--crate-type" && arg == "cdylib" {
-                        *arg = "rlib".into();
-                    }
+                if let Some(prev_arg) = iter.peek()
+                    && *prev_arg == "--crate-type"
+                    && arg == "cdylib"
+                {
+                    *arg = "rlib".into();
                 }
             }
             let mut cmd = cmd.clone();
@@ -222,16 +229,48 @@ pub fn cargo_env_target_cfg(tool: &str, target: &str) -> String {
     env.to_uppercase()
 }
 
-/// Ensure embedded Cargo always invokes the compiler selected when Crossbundle starts.
-///
-/// Cargo normally resolves the compiler to an absolute path. The embedded executor can instead
-/// receive the `rustup` shim as plain `rustc`; when Cargo runs that command from a dependency's
-/// directory, a dependency-local `rust-toolchain.toml` can unexpectedly switch toolchains.
-fn configure_rustc() -> Result<()> {
+fn workspace_root(project_path: &std::path::Path) -> Result<std::path::PathBuf> {
+    let cargo_context = cargo::util::GlobalContext::default()?;
+    let workspace = cargo::core::Workspace::new(&project_path.join("Cargo.toml"), &cargo_context)?;
+    Ok(workspace.root().to_owned())
+}
+
+/// Configure embedded Cargo without changing the process-global environment.
+fn configure_cargo(
+    cargo_context: &mut cargo::util::GlobalContext,
+    rust_triple: &str,
+    linker: &std::ffi::OsStr,
+    build_script_env: &[(String, std::ffi::OsString)],
+) -> Result<()> {
+    let mut overrides = Vec::with_capacity(build_script_env.len() + 2);
     if std::env::var_os("RUSTC").is_none() {
-        std::env::set_var("RUSTC", active_rustc_path()?);
+        overrides.push(config_value(
+            "build.rustc",
+            active_rustc_path()?.as_os_str(),
+        ));
     }
+
+    overrides.push(config_value(
+        &format!("target.{rust_triple}.linker"),
+        linker,
+    ));
+    overrides.extend(build_script_env.iter().map(|(name, value)| {
+        format!(
+            "env.{name} = {{ value = {}, force = true }}",
+            toml_string(value)
+        )
+    }));
+
+    cargo_context.configure(0, false, None, false, false, false, &None, &[], &overrides)?;
     Ok(())
+}
+
+fn config_value(key: &str, value: &std::ffi::OsStr) -> String {
+    format!("{key} = {}", toml_string(value))
+}
+
+fn toml_string(value: &std::ffi::OsStr) -> String {
+    format!("{:?}", value.to_string_lossy())
 }
 
 fn active_rustc_path() -> Result<std::path::PathBuf> {

--- a/crossbundle/tools/src/commands/android/common/rust_compile/rust_compiler.rs
+++ b/crossbundle/tools/src/commands/android/common/rust_compile/rust_compiler.rs
@@ -242,7 +242,7 @@ fn configure_cargo(
     linker: &std::ffi::OsStr,
     build_script_env: &[(String, std::ffi::OsString)],
 ) -> Result<()> {
-    let mut overrides = Vec::with_capacity(build_script_env.len() + 2);
+    let mut overrides = Vec::with_capacity(build_script_env.len() * 2 + 2);
     if std::env::var_os("RUSTC").is_none() {
         overrides.push(config_value(
             "build.rustc",
@@ -254,12 +254,13 @@ fn configure_cargo(
         &format!("target.{rust_triple}.linker"),
         linker,
     ));
-    overrides.extend(build_script_env.iter().map(|(name, value)| {
-        format!(
-            "env.{name} = {{ value = {}, force = true }}",
-            toml_string(value)
-        )
-    }));
+    for (name, value) in build_script_env {
+        // Cargo's `--config` parser does not accept inline tables, so provide the two
+        // fields as dotted keys. `force` preserves the old process-environment behavior:
+        // Crossbundle's selected NDK tools take precedence over inherited host values.
+        overrides.push(format!("env.{name}.value = {}", toml_string(value)));
+        overrides.push(format!("env.{name}.force = true"));
+    }
 
     cargo_context.configure(0, false, None, false, false, false, &None, &[], &overrides)?;
     Ok(())
@@ -289,8 +290,24 @@ fn active_rustc_path() -> Result<std::path::PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::active_rustc_path;
+    use super::{active_rustc_path, configure_cargo};
+    use std::ffi::{OsStr, OsString};
     use std::process::Command;
+
+    #[test]
+    fn cargo_accepts_build_script_environment_overrides() {
+        let mut context = cargo::util::GlobalContext::default().unwrap();
+        configure_cargo(
+            &mut context,
+            "aarch64-linux-android",
+            OsStr::new("/android/clang"),
+            &[(
+                "CC_aarch64-linux-android".to_owned(),
+                OsString::from("/android/clang"),
+            )],
+        )
+        .unwrap();
+    }
 
     #[test]
     fn resolved_rustc_ignores_dependency_toolchain_override() {

--- a/crossbundle/tools/src/commands/android/gradle/gen_gradle_project.rs
+++ b/crossbundle/tools/src/commands/android/gradle/gen_gradle_project.rs
@@ -197,7 +197,7 @@ mod tests {
             project_dir: Some(PathBuf::from("../../platform/android/java")),
         };
         assert_eq!(
-            get_settings_gradle(&[dep.clone()]).unwrap(),
+            get_settings_gradle(std::slice::from_ref(&dep)).unwrap(),
             format!(
                 "include \":crossbow\"\nproject(\":crossbow\").projectDir = new File(\"{}\")\n",
                 dunce::canonicalize(dep.project_dir.unwrap())

--- a/crossbundle/tools/src/commands/android/native/apk/add_libs_into_apk.rs
+++ b/crossbundle/tools/src/commands/android/native/apk/add_libs_into_apk.rs
@@ -183,12 +183,11 @@ pub fn get_libs_in_dir(dir: &Path) -> std::io::Result<Vec<String>> {
     if dir.is_dir() {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
-            if !entry.path().is_dir() {
-                if let Some(file_name) = entry.file_name().to_str() {
-                    if file_name.ends_with(".so") {
-                        libs.push(file_name.to_owned());
-                    }
-                }
+            if !entry.path().is_dir()
+                && let Some(file_name) = entry.file_name().to_str()
+                && file_name.ends_with(".so")
+            {
+                libs.push(file_name.to_owned());
             }
         }
     };

--- a/crossbundle/tools/src/commands/apple/gen_app_folder.rs
+++ b/crossbundle/tools/src/commands/apple/gen_app_folder.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use fs_extra::dir::{copy as copy_dir, CopyOptions};
+use fs_extra::dir::{CopyOptions, copy as copy_dir};
 use std::fs::{create_dir_all, remove_dir_all};
 use std::path::{Path, PathBuf};
 

--- a/crossbundle/tools/src/commands/apple/gen_ipa.rs
+++ b/crossbundle/tools/src/commands/apple/gen_ipa.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use fs_extra::dir::{copy as copy_dir, CopyOptions};
+use fs_extra::dir::{CopyOptions, copy as copy_dir};
 use std::fs::{create_dir_all, remove_dir_all};
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crossbundle/tools/src/commands/apple/launch_app.rs
+++ b/crossbundle/tools/src/commands/apple/launch_app.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use simctl::{list::DeviceState, Device, DeviceQuery, Simctl};
+use simctl::{Device, DeviceQuery, Simctl, list::DeviceState};
 use std::path::Path;
 
 pub fn launch_apple_app(

--- a/crossbundle/tools/src/commands/common/combine_folders.rs
+++ b/crossbundle/tools/src/commands/common/combine_folders.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use fs_extra::dir::{copy as copy_dir, CopyOptions};
+use fs_extra::dir::{CopyOptions, copy as copy_dir};
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 

--- a/crossbundle/tools/src/commands/common/gen_minimal_project/consts.rs
+++ b/crossbundle/tools/src/commands/common/gen_minimal_project/consts.rs
@@ -3,7 +3,7 @@ pub const MINIMAL_BEVY_CARGO_TOML_VALUE: &str = r#"
 name = "example"
 version = "0.1.0"
 authors = ["DodoRare Team <support@dodorare.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 crossbow = { git = "https://github.com/dodorare/crossbow" }
@@ -16,7 +16,7 @@ pub const MINIMAL_MQ_CARGO_TOML_VALUE: &str = r#"
 name = "example"
 version = "0.1.0"
 authors = ["DodoRare Team <support@dodorare.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 crossbow = { git = "https://github.com/dodorare/crossbow" }

--- a/crossbundle/tools/src/commands/common/gen_minimal_project/gen_min_project.rs
+++ b/crossbundle/tools/src/commands/common/gen_minimal_project/gen_min_project.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::error::*;
 use std::{
-    fs::{create_dir, File},
+    fs::{File, create_dir},
     io::Write,
 };
 

--- a/crossbundle/tools/src/commands/common/parse_manifest.rs
+++ b/crossbundle/tools/src/commands/common/parse_manifest.rs
@@ -1,8 +1,8 @@
 use crate::error::*;
 use cargo::{
     core::{EitherManifest, Manifest, SourceId},
-    util::toml::read_manifest,
     util::GlobalContext,
+    util::toml::read_manifest,
 };
 use std::path::Path;
 

--- a/crossbundle/tools/src/lib.rs
+++ b/crossbundle/tools/src/lib.rs
@@ -1,7 +1,7 @@
 /// On Windows adds `.exe` to given string.
 #[cfg(feature = "android")]
 macro_rules! bin {
-    ($bin:expr) => {{
+    ($bin:expr_2021) => {{
         #[cfg(not(target_os = "windows"))]
         let bin = $bin;
         #[cfg(target_os = "windows")]
@@ -13,7 +13,7 @@ macro_rules! bin {
 /// On Windows adds `.bat` to given string.
 #[cfg(feature = "android")]
 macro_rules! bat {
-    ($bat:expr) => {{
+    ($bat:expr_2021) => {{
         #[cfg(not(target_os = "windows"))]
         let bat = $bat;
         #[cfg(target_os = "windows")]

--- a/crossbundle/tools/src/types/android/android_ndk.rs
+++ b/crossbundle/tools/src/types/android/android_ndk.rs
@@ -43,18 +43,18 @@ impl AndroidNdk {
         let build_tag = build_tag
             .split('\n')
             .find_map(|line| {
-                if let Some((key, value)) = line.split_once('=') {
-                    if key.trim() == "Pkg.Revision" {
-                        // AOSP writes a constantly-incrementing build version to the patch field.
-                        // This number is incrementing across NDK releases.
-                        let mut parts = value.trim().split('.');
-                        let _major = parts.next().unwrap();
-                        let _minor = parts.next().unwrap();
-                        let patch = parts.next().unwrap();
-                        // Can have an optional `XXX-beta1`
-                        let patch = patch.split_once('-').map_or(patch, |(patch, _beta)| patch);
-                        return Some(patch.parse().expect("Failed to parse patch field"));
-                    }
+                if let Some((key, value)) = line.split_once('=')
+                    && key.trim() == "Pkg.Revision"
+                {
+                    // AOSP writes a constantly-incrementing build version to the patch field.
+                    // This number is incrementing across NDK releases.
+                    let mut parts = value.trim().split('.');
+                    let _major = parts.next().unwrap();
+                    let _minor = parts.next().unwrap();
+                    let patch = parts.next().unwrap();
+                    // Can have an optional `XXX-beta1`
+                    let patch = patch.split_once('-').map_or(patch, |(patch, _beta)| patch);
+                    return Some(patch.parse().expect("Failed to parse patch field"));
                 }
                 None
             })

--- a/crossbundle/tools/src/types/common/shell.rs
+++ b/crossbundle/tools/src/types/common/shell.rs
@@ -466,7 +466,7 @@ mod imp {
     use winapi::um::wincon::*;
     use winapi::um::winnt::*;
 
-    pub(super) use super::{default_err_erase_line as err_erase_line, TtyWidth};
+    pub(super) use super::{TtyWidth, default_err_erase_line as err_erase_line};
 
     pub fn stderr_width() -> TtyWidth {
         unsafe {

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,6 @@ highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     { crate = "bitflags@1.3.2", reason = "ndk 0.7 has not migrated to bitflags 2" },
-    { crate = "jni-sys@0.3.1", reason = "ndk 0.7 requires the compatibility JNI bindings" },
     { crate = "syn@1.0.109", reason = "ndk 0.7 still uses Syn 1 procedural macros" },
     { crate = "syn@2.0.119", reason = "Android manifest and JNI macros have not migrated to Syn 3" },
     { crate = "thiserror@1.0.69", reason = "ndk 0.7 has not migrated to thiserror 2" },

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     { crate = "bitflags@1.3.2", reason = "ndk 0.7 has not migrated to bitflags 2" },
+    { crate = "jni-sys@0.3.1", reason = "ndk 0.7 requires the compatibility JNI bindings" },
     { crate = "syn@1.0.109", reason = "ndk 0.7 still uses Syn 1 procedural macros" },
     { crate = "syn@2.0.119", reason = "Android manifest and JNI macros have not migrated to Syn 3" },
     { crate = "thiserror@1.0.69", reason = "ndk 0.7 has not migrated to thiserror 2" },

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,4 +5,4 @@ authors = ["DodoRare Team <support@dodorare.com>"]
 language = "en"
 
 [rust]
-edition = "2021"
+edition = "2024"

--- a/docs/src/crossbow/configuration.md
+++ b/docs/src/crossbow/configuration.md
@@ -9,7 +9,7 @@ The easiest way to configure a project is with metadata. Here's an example of `C
 name = "game"
 version = "0.1.0"
 authors = ["Example <example@example.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 crossbow = "0.2.3"

--- a/docs/src/tutorials/hello-world.md
+++ b/docs/src/tutorials/hello-world.md
@@ -18,7 +18,7 @@ To see all possibilities of `cargo.toml` see [crossbow configutarion tutorial](.
 name = "project-name"
 version = "0.1.0"
 authors = ["Example <example@example.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 crossbow = "*"

--- a/examples/bevy-2d/Cargo.toml
+++ b/examples/bevy-2d/Cargo.toml
@@ -2,13 +2,13 @@
 name = "bevy-2d"
 version = "0.2.3"
 authors = ["DodoRare Team <support@dodorare.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
-crossbow = { version = "0.2.3", path = "../../" }
-log = "0.4"
-anyhow = "1.0"
-bevy = { version = "0.19.0", default-features = false, features = ["2d"] }
+crossbow = { workspace = true, default-features = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+bevy = { workspace = true, default-features = false, features = ["2d"] }
 
 [package.metadata]
 app_name = "Bevy 2D"

--- a/examples/crossbow-plugins/Cargo.toml
+++ b/examples/crossbow-plugins/Cargo.toml
@@ -2,18 +2,18 @@
 name = "crossbow-plugins"
 version = "0.2.3"
 authors = ["DodoRare Team <support@dodorare.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
-crossbow = { version = "0.2.3", path = "../../" }
-log = "0.4"
-anyhow = "1.0"
-macroquad = "0.4.16"
+crossbow = { workspace = true, default-features = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+macroquad = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-play-core = { version = "0.2.3", path = "../../plugins/play-core" }
-play-billing = { version = "0.2.3", path = "../../plugins/play-billing" }
-play-games-services = { version = "0.2.3", path = "../../plugins/play-games-services" }
+play-core = { workspace = true }
+play-billing = { workspace = true }
+play-games-services = { workspace = true }
 
 [package.metadata]
 app_name = "Crossbow Plugins"

--- a/examples/crossbow-plugins/src/main.rs
+++ b/examples/crossbow-plugins/src/main.rs
@@ -1,5 +1,5 @@
 use macroquad::prelude::*;
-use macroquad::ui::{hash, root_ui, Skin};
+use macroquad::ui::{Skin, hash, root_ui};
 
 #[cfg(target_os = "android")]
 struct AppPlugins {

--- a/examples/macroquad-3d/Cargo.toml
+++ b/examples/macroquad-3d/Cargo.toml
@@ -2,13 +2,13 @@
 name = "macroquad-3d"
 version = "0.2.3"
 authors = ["DodoRare Team <support@dodorare.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
-crossbow = { version = "0.2.3", path = "../../" }
-log = "0.4"
-anyhow = "1.0"
-macroquad = "0.4.16"
+crossbow = { workspace = true, default-features = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+macroquad = { workspace = true }
 
 [package.metadata]
 app_name = "Macroquad 3D"

--- a/examples/macroquad-3d/src/main.rs
+++ b/examples/macroquad-3d/src/main.rs
@@ -55,6 +55,5 @@ fn get_assets_from_path() -> String {
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let assets_dir = manifest_dir.parent().unwrap().parent().unwrap();
     let image_path = std::path::PathBuf::from("assets").join("images/rust.png");
-    let image = assets_dir.join(image_path).to_str().unwrap().to_owned();
-    image
+    assets_dir.join(image_path).to_str().unwrap().to_owned()
 }

--- a/examples/macroquad-permissions/Cargo.toml
+++ b/examples/macroquad-permissions/Cargo.toml
@@ -2,16 +2,16 @@
 name = "macroquad-permissions"
 version = "0.2.3"
 authors = ["DodoRare Team <support@dodorare.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
-crossbow = { version = "0.2.3", path = "../../" }
-log = "0.4"
-anyhow = "1.0"
-macroquad = "0.4.16"
+crossbow = { workspace = true, default-features = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+macroquad = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-admob-android = { version = "0.2.3", path = "../../plugins/admob-android" }
+admob-android = { workspace = true }
 
 [package.metadata]
 app_name = "Permissions"

--- a/examples/macroquad-permissions/src/main.rs
+++ b/examples/macroquad-permissions/src/main.rs
@@ -1,6 +1,6 @@
 use crossbow::Permission;
 use macroquad::prelude::*;
-use macroquad::ui::{hash, root_ui, Skin};
+use macroquad::ui::{Skin, hash, root_ui};
 
 #[macroquad::main("Macroquad UI")]
 async fn main() -> anyhow::Result<()> {

--- a/platform/android/Cargo.toml
+++ b/platform/android/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossbow-android"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform build tools and toolkit for games"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,16 +11,16 @@ readme = "README.md"
 include = ["src/", "java/app/"]
 
 [dependencies]
-thiserror = "2.0"
-displaydoc = "0.2"
-anyhow = "1.0"
+thiserror = { workspace = true }
+displaydoc = { workspace = true }
+anyhow = { workspace = true }
 
-rust-embed = { version = "8.12.0", features = ["include-exclude"], optional = true }
+rust-embed = { workspace = true, features = ["include-exclude"], optional = true }
 
-jni = { version = "0.22", optional = true }
-ndk-context = { version = "0.1", optional = true }
-lazy_static = { version = "1.5", optional = true }
-async-channel = { version = "2.5", optional = true }
+jni = { workspace = true, optional = true }
+ndk-context = { workspace = true, optional = true }
+lazy_static = { workspace = true, optional = true }
+async-channel = { workspace = true, optional = true }
 
 [features]
 default = ["android"]

--- a/platform/android/src/crossbow.rs
+++ b/platform/android/src/crossbow.rs
@@ -3,10 +3,9 @@ use crate::{
     utils::jstring_to_string,
 };
 use jni::{
-    jni_sig, jni_str,
+    Env, jni_sig, jni_str,
     objects::{JObject, JString},
-    sys::{jboolean, JNI_TRUE},
-    Env,
+    sys::{JNI_TRUE, jboolean},
 };
 use std::sync::Arc;
 

--- a/platform/android/src/externs/crossbow_lib.rs
+++ b/platform/android/src/externs/crossbow_lib.rs
@@ -1,12 +1,12 @@
 use crate::crossbow::*;
 use jni::{
+    EnvUnowned,
     errors::ThrowRuntimeExAndDefault,
     objects::{JClass, JObject, JString},
     sys::jboolean,
-    EnvUnowned,
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_CrossbowLib_initialize<'local>(
     mut env: EnvUnowned<'local>,
@@ -21,7 +21,7 @@ pub extern "system" fn Java_com_crossbow_library_CrossbowLib_initialize<'local>(
     .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_CrossbowLib_onBackPressed<'local>(
     mut env: EnvUnowned<'local>,
@@ -31,7 +31,7 @@ pub extern "system" fn Java_com_crossbow_library_CrossbowLib_onBackPressed<'loca
         .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_CrossbowLib_onDestroy<'local>(
     mut env: EnvUnowned<'local>,
@@ -41,7 +41,7 @@ pub extern "system" fn Java_com_crossbow_library_CrossbowLib_onDestroy<'local>(
         .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_CrossbowLib_focusIn<'local>(
     mut env: EnvUnowned<'local>,
@@ -51,7 +51,7 @@ pub extern "system" fn Java_com_crossbow_library_CrossbowLib_focusIn<'local>(
         .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_CrossbowLib_focusOut<'local>(
     mut env: EnvUnowned<'local>,
@@ -61,7 +61,7 @@ pub extern "system" fn Java_com_crossbow_library_CrossbowLib_focusOut<'local>(
         .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_CrossbowLib_requestPermissionResult<'local>(
     mut env: EnvUnowned<'local>,

--- a/platform/android/src/externs/crossbow_plugin.rs
+++ b/platform/android/src/externs/crossbow_plugin.rs
@@ -1,11 +1,11 @@
 use crate::plugin::*;
 use jni::{
+    EnvUnowned,
     errors::ThrowRuntimeExAndDefault,
     objects::{JClass, JObject, JObjectArray, JString},
-    EnvUnowned,
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeRegisterSingleton<
     'local,
@@ -19,7 +19,7 @@ pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeReg
         .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeRegisterMethod<
     'local,
@@ -34,7 +34,7 @@ pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeReg
         .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeRegisterSignal<
     'local,
@@ -51,7 +51,7 @@ pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeReg
     .resolve::<ThrowRuntimeExAndDefault>();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub extern "system" fn Java_com_crossbow_library_plugin_CrossbowPlugin_nativeEmitSignal<'local>(
     mut env: EnvUnowned<'local>,

--- a/platform/android/src/permission/mod.rs
+++ b/platform/android/src/permission/mod.rs
@@ -5,8 +5,8 @@ pub use android_permission::*;
 
 use crate::error::*;
 use std::sync::{
-    mpsc::{sync_channel, SyncSender},
     RwLock,
+    mpsc::{SyncSender, sync_channel},
 };
 
 lazy_static::lazy_static! {

--- a/platform/android/src/permission/request_permission.rs
+++ b/platform/android/src/permission/request_permission.rs
@@ -1,10 +1,9 @@
 use super::AndroidPermission;
 use crate::error::*;
 use jni::{
-    jni_sig, jni_str,
+    Env, jni_sig, jni_str,
     objects::{JObject, JObjectArray, JString, JValue, JValueOwned},
     strings::JNIString,
-    Env,
 };
 use std::mem::ManuallyDrop;
 

--- a/platform/android/src/plugin/handlers.rs
+++ b/platform/android/src/plugin/handlers.rs
@@ -2,9 +2,9 @@ use super::*;
 use crate::{error::*, utils::*};
 use async_channel::unbounded;
 use jni::{
+    Env,
     objects::{JObject, JObjectArray, JString},
     signature::{JavaType, RuntimeMethodSignature},
-    Env,
 };
 
 pub(crate) fn on_native_register_singleton(

--- a/platform/android/src/plugin/jni_rust_type.rs
+++ b/platform/android/src/plugin/jni_rust_type.rs
@@ -1,8 +1,7 @@
 use crate::{error::*, utils::*};
 use jni::{
-    jni_sig, jni_str,
+    Env, jni_sig, jni_str,
     objects::{JByteArray, JDoubleArray, JFloatArray, JIntArray, JObject, JObjectArray, JString},
-    Env,
 };
 use std::{collections::HashMap, fmt::Display};
 

--- a/platform/android/src/plugin/jni_singleton.rs
+++ b/platform/android/src/plugin/jni_singleton.rs
@@ -1,11 +1,11 @@
 use super::JniRustType;
 use async_channel::Receiver;
 use jni::{
+    Env,
     errors::*,
     objects::{Global, JObject, JValue, JValueOwned},
     signature::{JavaType, RuntimeMethodSignature},
     strings::JNIString,
-    Env,
 };
 use std::{collections::HashMap, sync::Arc};
 

--- a/platform/android/src/plugin/mod.rs
+++ b/platform/android/src/plugin/mod.rs
@@ -48,12 +48,11 @@ fn insert_sender(singleton_name: &str, sender: Sender<Signal>) -> Option<Sender<
 }
 
 pub fn get_jni_singleton_with_error(singleton_name: &str) -> Result<Arc<JniSingleton>> {
-    if let Some(jni_signleton) = get_jni_singleton(singleton_name) {
-        Ok(jni_signleton)
-    } else {
-        Err(AndroidError::SingletonNotRegistered(
+    match get_jni_singleton(singleton_name) {
+        Some(jni_signleton) => Ok(jni_signleton),
+        _ => Err(AndroidError::SingletonNotRegistered(
             singleton_name.to_owned(),
-        ))
+        )),
     }
 }
 

--- a/platform/android/src/utils.rs
+++ b/platform/android/src/utils.rs
@@ -1,8 +1,7 @@
 use crate::error::*;
 use jni::{
-    jni_sig, jni_str,
+    Env, jni_sig, jni_str,
     objects::{JClass, JString},
-    Env,
 };
 
 pub fn jstring_to_string(env: &Env, jstring: &JString) -> Result<String> {

--- a/platform/ios/Cargo.toml
+++ b/platform/ios/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossbow-ios"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Cross-Platform build tools and toolkit for games"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,15 +11,12 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-thiserror = "2.0"
-displaydoc = "0.2"
-anyhow = "1.0"
+thiserror = { workspace = true }
+displaydoc = { workspace = true }
+anyhow = { workspace = true }
 
-objc = "0.2"
-block = "0.1"
-cocoa-foundation = "0.2"
-core-foundation = "0.10"
-libc = "0.2"
+objc2 = { workspace = true }
+block2 = { workspace = true }
 
 [features]
 default = [

--- a/platform/ios/src/permission/mod.rs
+++ b/platform/ios/src/permission/mod.rs
@@ -58,7 +58,7 @@ where
         }
         IosPermission::MotionActivityManager => {
             request_motion_activity_permission(move |activities, _error| {
-                if activities != cocoa_foundation::base::nil {
+                if !activities.is_null() {
                     handler(AuthorizationStatus::Authorized);
                 } else {
                     handler(AuthorizationStatus::Denied);

--- a/platform/ios/src/permission/request_permission.rs
+++ b/platform/ios/src/permission/request_permission.rs
@@ -1,21 +1,21 @@
 use super::*;
-use cocoa_foundation::{
-    base::{id, nil},
-    foundation::NSUInteger,
+use block2::RcBlock;
+use objc2::{
+    class, msg_send,
+    runtime::{AnyObject, Bool},
 };
-use objc::{class, msg_send, sel, sel_impl};
 
 pub fn request_capture_device_permission<F>(media: &MediaType, handler: F)
 where
     F: Fn(bool) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |success: bool| handler(success));
-    let opt: id = media.into();
+    let block = RcBlock::new(move |success: Bool| handler(success.as_bool()));
+    let opt: Object = media.into();
     let _: () = unsafe {
         msg_send![
             class!(AVCaptureDevice),
-            requestAccessForMediaType: opt
-            completionHandler: block.copy()
+            requestAccessForMediaType: opt,
+            completionHandler: &*block
         ]
     };
 }
@@ -24,55 +24,55 @@ pub fn request_photo_library_permission<F>(level: &AccessLevel, handler: F)
 where
     F: Fn(AuthorizationStatus) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |res: NSUInteger| {
+    let block = RcBlock::new(move |res: usize| {
         handler(AuthorizationStatus::from(res));
     });
-    let opt: NSUInteger = level.into();
+    let opt: usize = level.into();
     let _: () = unsafe {
         msg_send![
             class!(PHPhotoLibrary),
-            requestAuthorizationForAccessLevel: opt
-            handler: block.copy()
+            requestAuthorizationForAccessLevel: opt,
+            handler: &*block
         ]
     };
 }
 
 pub fn request_calendar_permission<F>(entity_type: &EntityType, handler: F)
 where
-    F: Fn(bool, id) + Send + Sync + 'static,
+    F: Fn(bool, Object) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |granted: bool, error: id| {
-        handler(granted, error);
+    let block = RcBlock::new(move |granted: Bool, error: Object| {
+        handler(granted.as_bool(), error);
     });
-    let opt: NSUInteger = entity_type.into();
+    let opt: usize = entity_type.into();
     let _: () = unsafe {
         msg_send![
             class!(EKEventStore),
-            requestAccessToEntityType: opt
-            completion: block.copy()
+            requestAccessToEntityType: opt,
+            completion: &*block
         ]
     };
 }
 
 pub fn request_address_book_permission<F>(handler: F)
 where
-    F: Fn(bool, id) + Send + Sync + 'static,
+    F: Fn(bool, Object) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |granted: bool, error: id| {
-        handler(granted, error);
+    let block = RcBlock::new(move |granted: Bool, error: Object| {
+        handler(granted.as_bool(), error);
     });
     let _: () = unsafe {
         // https://developer.apple.com/documentation/addressbook/1621991-abaddressbookcreatewithoptions
-        let address_book_ref: id = msg_send![
+        let address_book_ref: Object = msg_send![
             class!(ABAddressBook),
-            ABAddressBookCreateWithOptions: nil
-            error: nil
+            ABAddressBookCreateWithOptions: std::ptr::null_mut::<AnyObject>(),
+            error: std::ptr::null_mut::<AnyObject>()
         ];
         // https://developer.apple.com/documentation/addressbook/1622001-abaddressbookrequestaccesswithco
         msg_send![
             class!(ABAddressBook),
-            ABAddressBookRequestAccessWithCompletion: address_book_ref
-            completion: block.copy()
+            ABAddressBookRequestAccessWithCompletion: address_book_ref,
+            completion: &*block
         ]
     };
 }
@@ -81,14 +81,14 @@ pub fn request_media_permission<F>(handler: F)
 where
     F: Fn(MediaLibraryAuthorizationStatus) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |status: NSUInteger| {
+    let block = RcBlock::new(move |status: usize| {
         handler(MediaLibraryAuthorizationStatus::from(status));
     });
     let _: () = unsafe {
         // https://developer.apple.com/documentation/mediaplayer/mpmedialibrary/1621276-requestauthorization
         msg_send![
             class!(MPMediaLibrary),
-            requestAuthorization: block.copy()
+            requestAuthorization: &*block
         ]
     };
 }
@@ -97,33 +97,33 @@ pub fn request_speech_recognition_permission<F>(handler: F)
 where
     F: Fn(SpeechRecognizerAuthorizationStatus) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |status: NSUInteger| {
+    let block = RcBlock::new(move |status: usize| {
         handler(SpeechRecognizerAuthorizationStatus::from(status));
     });
     let _: () = unsafe {
         // https://developer.apple.com/documentation/mediaplayer/mpmedialibrary/1621276-requestauthorization
         msg_send![
             class!(SFSpeechRecognizer),
-            requestAuthorization: block.copy()
+            requestAuthorization: &*block
         ]
     };
 }
 
 pub fn request_motion_activity_permission<F>(handler: F)
 where
-    F: Fn(id, id) + Send + Sync + 'static,
+    F: Fn(Object, Object) + Send + Sync + 'static,
 {
-    let block = block::ConcreteBlock::new(move |activities: id, error: id| {
+    let block = RcBlock::new(move |activities: Object, error: Object| {
         handler(activities, error);
     });
     let _: () = unsafe {
         // https://developer.apple.com/documentation/coremotion/cmmotionactivitymanager/1615929-queryactivitystartingfromdate
         msg_send![
             class!(CMMotionActivityManager),
-            queryActivityStartingFromDate: nil
-            toDate: nil
-            toQueue: nil
-            handler: block.copy()
+            queryActivityStartingFromDate: std::ptr::null_mut::<AnyObject>(),
+            toDate: std::ptr::null_mut::<AnyObject>(),
+            toQueue: std::ptr::null_mut::<AnyObject>(),
+            handler: &*block
         ]
     };
 }

--- a/platform/ios/src/permission/request_permission.rs
+++ b/platform/ios/src/permission/request_permission.rs
@@ -10,7 +10,7 @@ where
     F: Fn(bool) + Send + Sync + 'static,
 {
     let block = RcBlock::new(move |success: Bool| handler(success.as_bool()));
-    let opt: Object = media.into();
+    let opt: ObjcObjectPtr = media.into();
     let _: () = unsafe {
         msg_send![
             class!(AVCaptureDevice),
@@ -39,9 +39,9 @@ where
 
 pub fn request_calendar_permission<F>(entity_type: &EntityType, handler: F)
 where
-    F: Fn(bool, Object) + Send + Sync + 'static,
+    F: Fn(bool, ObjcObjectPtr) + Send + Sync + 'static,
 {
-    let block = RcBlock::new(move |granted: Bool, error: Object| {
+    let block = RcBlock::new(move |granted: Bool, error: ObjcObjectPtr| {
         handler(granted.as_bool(), error);
     });
     let opt: usize = entity_type.into();
@@ -56,14 +56,14 @@ where
 
 pub fn request_address_book_permission<F>(handler: F)
 where
-    F: Fn(bool, Object) + Send + Sync + 'static,
+    F: Fn(bool, ObjcObjectPtr) + Send + Sync + 'static,
 {
-    let block = RcBlock::new(move |granted: Bool, error: Object| {
+    let block = RcBlock::new(move |granted: Bool, error: ObjcObjectPtr| {
         handler(granted.as_bool(), error);
     });
     let _: () = unsafe {
         // https://developer.apple.com/documentation/addressbook/1621991-abaddressbookcreatewithoptions
-        let address_book_ref: Object = msg_send![
+        let address_book_ref: ObjcObjectPtr = msg_send![
             class!(ABAddressBook),
             ABAddressBookCreateWithOptions: std::ptr::null_mut::<AnyObject>(),
             error: std::ptr::null_mut::<AnyObject>()
@@ -111,9 +111,9 @@ where
 
 pub fn request_motion_activity_permission<F>(handler: F)
 where
-    F: Fn(Object, Object) + Send + Sync + 'static,
+    F: Fn(ObjcObjectPtr, ObjcObjectPtr) + Send + Sync + 'static,
 {
-    let block = RcBlock::new(move |activities: Object, error: Object| {
+    let block = RcBlock::new(move |activities: ObjcObjectPtr, error: ObjcObjectPtr| {
         handler(activities, error);
     });
     let _: () = unsafe {

--- a/platform/ios/src/permission/types.rs
+++ b/platform/ios/src/permission/types.rs
@@ -1,7 +1,9 @@
 use objc2::runtime::AnyObject;
 
-/// Untyped Objective-C object pointer used by the legacy permission APIs.
-pub type Object = *mut AnyObject;
+/// Borrowed Objective-C object pointer used by the legacy permission APIs.
+///
+/// These APIs do not transfer ownership, and callback error values may be null.
+pub type ObjcObjectPtr = *mut AnyObject;
 
 /// Type for iOS Permission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,11 +86,11 @@ pub enum MediaType {
 
 #[link(name = "AVFoundation", kind = "framework")]
 unsafe extern "C" {
-    pub static AVMediaTypeVideo: Object;
-    pub static AVMediaTypeAudio: Object;
+    pub static AVMediaTypeVideo: ObjcObjectPtr;
+    pub static AVMediaTypeAudio: ObjcObjectPtr;
 }
 
-impl From<&MediaType> for Object {
+impl From<&MediaType> for ObjcObjectPtr {
     fn from(media_type: &MediaType) -> Self {
         match media_type {
             MediaType::Audio => unsafe { AVMediaTypeAudio },

--- a/platform/ios/src/permission/types.rs
+++ b/platform/ios/src/permission/types.rs
@@ -1,4 +1,7 @@
-use cocoa_foundation::{base::id, foundation::NSUInteger};
+use objc2::runtime::AnyObject;
+
+/// Untyped Objective-C object pointer used by the legacy permission APIs.
+pub type Object = *mut AnyObject;
 
 /// Type for iOS Permission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,14 +83,14 @@ pub enum MediaType {
 }
 
 #[link(name = "AVFoundation", kind = "framework")]
-extern "C" {
-    pub static AVMediaTypeVideo: id;
-    pub static AVMediaTypeAudio: id;
+unsafe extern "C" {
+    pub static AVMediaTypeVideo: Object;
+    pub static AVMediaTypeAudio: Object;
 }
 
-impl Into<id> for &MediaType {
-    fn into(self) -> id {
-        match self {
+impl From<&MediaType> for Object {
+    fn from(media_type: &MediaType) -> Self {
+        match media_type {
             MediaType::Audio => unsafe { AVMediaTypeAudio },
             MediaType::Video => unsafe { AVMediaTypeVideo },
         }
@@ -108,9 +111,9 @@ pub enum AccessLevel {
     ReadWrite,
 }
 
-impl Into<NSUInteger> for &AccessLevel {
-    fn into(self) -> NSUInteger {
-        match self {
+impl From<&AccessLevel> for usize {
+    fn from(access_level: &AccessLevel) -> Self {
+        match access_level {
             AccessLevel::AddOnly => 1 << 0,
             AccessLevel::ReadWrite => 1 << 1,
         }
@@ -137,8 +140,8 @@ pub enum AuthorizationStatus {
     Limited,
 }
 
-impl From<NSUInteger> for AuthorizationStatus {
-    fn from(integer: NSUInteger) -> Self {
+impl From<usize> for AuthorizationStatus {
+    fn from(integer: usize) -> Self {
         match integer {
             0 => Self::NotDetermined,
             1 => Self::Restricted,
@@ -162,9 +165,9 @@ pub enum EntityType {
     Reminder,
 }
 
-impl Into<NSUInteger> for &EntityType {
-    fn into(self) -> NSUInteger {
-        match self {
+impl From<&EntityType> for usize {
+    fn from(entity_type: &EntityType) -> Self {
+        match entity_type {
             EntityType::Event => 0,
             EntityType::Reminder => 1,
         }
@@ -188,8 +191,8 @@ pub enum MediaLibraryAuthorizationStatus {
     Authorized,
 }
 
-impl From<NSUInteger> for MediaLibraryAuthorizationStatus {
-    fn from(integer: NSUInteger) -> Self {
+impl From<usize> for MediaLibraryAuthorizationStatus {
+    fn from(integer: usize) -> Self {
         match integer {
             0 => Self::NotDetermined,
             1 => Self::Denied,

--- a/plugins/admob-android/Cargo.toml
+++ b/plugins/admob-android/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "admob-android"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "AdMob Plugin for Crossbow"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,4 +11,4 @@ readme = "README.md"
 exclude = ["android/"]
 
 [dependencies]
-crossbow-android = { path = "../../platform/android", version = "0.2.3" }
+crossbow-android = { workspace = true, default-features = true }

--- a/plugins/admob-android/src/lib.rs
+++ b/plugins/admob-android/src/lib.rs
@@ -1,6 +1,6 @@
 use crossbow_android::{
     error::*,
-    jni::{objects::JString, JavaVM},
+    jni::{JavaVM, objects::JString},
     plugin::*,
 };
 use std::sync::Arc;

--- a/plugins/play-billing/Cargo.toml
+++ b/plugins/play-billing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "play-billing"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Google Play Billing Plugin for Crossbow"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,4 +11,4 @@ readme = "README.md"
 exclude = ["android/"]
 
 [dependencies]
-crossbow-android = { path = "../../platform/android", version = "0.2.3" }
+crossbow-android = { workspace = true, default-features = true }

--- a/plugins/play-billing/src/lib.rs
+++ b/plugins/play-billing/src/lib.rs
@@ -1,6 +1,6 @@
 use crossbow_android::{
     error::*,
-    jni::{objects::JObjectArray, objects::JString, JavaVM},
+    jni::{JavaVM, objects::JObjectArray, objects::JString},
     plugin::*,
 };
 use std::sync::Arc;

--- a/plugins/play-core/Cargo.toml
+++ b/plugins/play-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "play-core"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Google Play Core Plugin for Crossbow"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,4 +11,4 @@ readme = "README.md"
 exclude = ["android/"]
 
 [dependencies]
-crossbow-android = { path = "../../platform/android", version = "0.2.3" }
+crossbow-android = { workspace = true, default-features = true }

--- a/plugins/play-games-services/Cargo.toml
+++ b/plugins/play-games-services/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "play-games-services"
 version = "0.2.3"
-edition = "2021"
+edition.workspace = true
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Google Play Games Services Plugin for Crossbow"
 repository = "https://github.com/dodorare/crossbow"
@@ -11,4 +11,4 @@ readme = "README.md"
 exclude = ["android/"]
 
 [dependencies]
-crossbow-android = { path = "../../platform/android", version = "0.2.3" }
+crossbow-android = { workspace = true, default-features = true }

--- a/plugins/play-games-services/src/lib.rs
+++ b/plugins/play-games-services/src/lib.rs
@@ -1,6 +1,6 @@
 use crossbow_android::{
     error::*,
-    jni::{objects::JObjectArray, objects::JString, JavaVM},
+    jni::{JavaVM, objects::JObjectArray, objects::JString},
     plugin::*,
 };
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

- migrate every workspace package to Rust edition 2024 and Cargo resolver 3
- centralize dependency versions and paths in the root `[workspace.dependencies]` table
- make every member manifest inherit dependencies with `{ workspace = true }`
- update source code, generated projects, and generated Android entry-point glue for Rust 2024
- replace the deprecated iOS Objective-C stack with `objc2` and `block2`
- preserve Android default-feature behavior and configure embedded Cargo without process-global environment mutation
- update the dependency workflow to the current artifact action runtime

## Why

This gives the repository one authoritative dependency catalog, moves all packages and generated projects to the current Rust edition, and removes deprecated or Rust-2024-incompatible code paths while preserving existing platform behavior.

## Validation

- `cargo fmt --all -- --check`
- strict workspace Clippy with warnings denied
- `cargo deny check`
- locked metadata and tool-version consistency checks
- exact Apple Crossbundle tools/CLI test matrix and `crossbow-ios` tests
- generated Rust 2024 iOS release builds
- full Linux/Android fresh-resolution workspace build and test workflow, including generated Bevy and Macroquad Android builds: https://github.com/dodorare/crossbow/actions/runs/31697622801

Independent Standards and Spec reviews found no remaining actionable issues.
