### PR TITLE
Replace unmaintained atty dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,17 +419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,7 +2390,6 @@ dependencies = [
  "android-tools",
  "anyhow",
  "apple-bundle",
- "atty",
  "creator-simctl",
  "crossbow",
  "crossbow-android",
@@ -3214,15 +3202,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -3502,7 +3481,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -4537,7 +4516,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ android-tools = "0.2.11"
 anyhow = "1.0"
 apple-bundle = "0.2.1"
 async-channel = "2.5"
-atty = "0.2"
 bevy = { version = "0.19.0", default-features = false }
 block2 = "0.6.2"
 clap = "4.6"

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -87,7 +87,6 @@ anyhow = { workspace = true }
 displaydoc = { workspace = true }
 log = { workspace = true }
 termcolor = { workspace = true }
-atty = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crossbundle/tools/src/types/common/shell.rs
+++ b/crossbundle/tools/src/types/common/shell.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::io::prelude::*;
+use std::io::{IsTerminal, prelude::*};
 
 use termcolor::Color::{Cyan, Green, Red, Yellow};
 use termcolor::{self, Color, ColorSpec, StandardStream, WriteColor};
@@ -102,7 +102,7 @@ impl Shell {
                 stdout: StandardStream::stdout(auto),
                 stderr: StandardStream::stderr(auto),
                 color_choice: ColorChoice::CargoAuto,
-                stderr_tty: atty::is(atty::Stream::Stderr),
+                stderr_tty: std::io::stderr().is_terminal(),
             },
             verbosity: Verbosity::Verbose,
             needs_clear: false,
@@ -417,7 +417,7 @@ impl ColorChoice {
             ColorChoice::Always => termcolor::ColorChoice::Always,
             ColorChoice::Never => termcolor::ColorChoice::Never,
             ColorChoice::CargoAuto => {
-                if atty::is(atty::Stream::Stderr) {
+                if std::io::stderr().is_terminal() {
                     termcolor::ColorChoice::Auto
                 } else {
                     termcolor::ColorChoice::Never


### PR DESCRIPTION
## Summary

Replace the unmaintained `atty` dependency with `std::io::IsTerminal`, resolving Dependabot alert.

## Validation

- `cargo check -p crossbundle-tools`
- `cargo fmt --all -- --check`
- `cargo test -p crossbundle-tools --no-default-features`