### PR TITLE
Replace redundant Rust dependencies with standard library APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,25 +2302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,7 +2414,6 @@ dependencies = [
  "toml",
  "winapi",
  "zip",
- "zip-extensions",
 ]
 
 [[package]]
@@ -3394,22 +3374,6 @@ name = "icu_segmenter_data"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
-
-[[package]]
-name = "ignore"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
 
 [[package]]
 name = "image"
@@ -6793,16 +6757,6 @@ dependencies = [
  "indexmap",
  "memchr",
  "typed-path",
-]
-
-[[package]]
-name = "zip-extensions"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285251480403d7097be64d5c33518279ecf5f816d5ebe403c476e45ea16c5628"
-dependencies = [
- "ignore",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,11 +176,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de28dd3564434218f78362c8d906db2fde6f1e4158fae7290f7bfc533aa561b9"
 dependencies = [
- "dirs 4.0.0",
+ "dirs",
  "displaydoc",
  "thiserror 1.0.69",
  "walkdir",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -1175,7 +1175,7 @@ dependencies = [
  "bevy_reflect",
  "derive_more",
  "glam 0.32.1",
- "itertools 0.14.0",
+ "itertools",
  "libm",
  "rand",
  "rand_distr",
@@ -1418,7 +1418,7 @@ dependencies = [
  "glam 0.32.1",
  "image 0.25.10",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "js-sys",
  "naga",
  "nonmax",
@@ -2357,7 +2357,6 @@ dependencies = [
  "async-channel",
  "displaydoc",
  "jni",
- "lazy_static",
  "ndk-context",
  "rust-embed",
  "thiserror 2.0.20",
@@ -2397,13 +2396,11 @@ dependencies = [
  "colored",
  "crossbow",
  "crossbundle-tools",
- "dirs 6.0.0",
  "displaydoc",
  "dunce",
  "fs_extra",
  "log",
  "pretty_env_logger",
- "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
@@ -2421,24 +2418,19 @@ dependencies = [
  "creator-simctl",
  "crossbow",
  "crossbow-android",
- "dirs 6.0.0",
  "displaydoc",
  "dunce",
  "fs_extra",
  "fwdansi",
  "image 0.25.10",
- "itertools 0.15.0",
  "libc",
- "log",
  "semver",
  "serde",
  "serde_json",
- "serde_plain",
  "tempfile",
  "termcolor",
  "thiserror 2.0.20",
  "toml",
- "which 8.0.5",
  "winapi",
  "zip",
  "zip-extensions",
@@ -2528,16 +2520,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2547,20 +2530,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3536,15 +3507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4364,12 +4326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4853,17 +4809,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6299,15 +6244,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
-]
-
-[[package]]
-name = "which"
-version = "8.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,6 @@ dependencies = [
  "crossbundle-tools",
  "displaydoc",
  "dunce",
- "fs_extra",
  "log",
  "pretty_env_logger",
  "serde_json",
@@ -2401,7 +2400,6 @@ dependencies = [
  "crossbow-android",
  "displaydoc",
  "dunce",
- "fs_extra",
  "fwdansi",
  "image 0.25.10",
  "libc",
@@ -2827,12 +2825,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,12 @@ crossbow = { path = ".", version = "0.2.3", default-features = false }
 crossbow-android = { path = "platform/android", version = "0.2.3", default-features = false }
 crossbow-ios = { path = "platform/ios", version = "0.2.3" }
 crossbundle-tools = { path = "crossbundle/tools", version = "0.2.3", default-features = false }
-dirs = "6.0"
 displaydoc = "0.2"
 dunce = "1.0"
 fs_extra = "1.3"
 fwdansi = "1.1"
 image = { version = "0.25.10", default-features = false }
-itertools = "0.15"
 jni = "0.22"
-lazy_static = "1.5"
 libc = "0.2"
 log = "0.4"
 macroquad = "0.4.16"
@@ -47,7 +44,6 @@ pretty_env_logger = "0.5"
 rust-embed = "8.12.0"
 serde = "1.0"
 serde_json = "1.0"
-serde_plain = "1.0"
 semver = "1.0"
 toml = "1.1"
 simctl = { version = "0.1.1", package = "creator-simctl" }
@@ -55,7 +51,6 @@ tempfile = "3.27"
 termcolor = "1.4"
 thiserror = "2.0"
 ureq = "3.4"
-which = "8.0"
 winapi = "0.3"
 zip = { version = "8.6.0", default-features = false }
 zip-extensions = { version = "0.14.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ crossbow-ios = { path = "platform/ios", version = "0.2.3" }
 crossbundle-tools = { path = "crossbundle/tools", version = "0.2.3", default-features = false }
 displaydoc = "0.2"
 dunce = "1.0"
-fs_extra = "1.3"
 fwdansi = "1.1"
 image = { version = "0.25.10", default-features = false }
 jni = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ thiserror = "2.0"
 ureq = "3.4"
 winapi = "0.3"
 zip = { version = "8.6.0", default-features = false }
-zip-extensions = { version = "0.14.1", default-features = false }
 
 [package]
 name = "crossbow"

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -31,7 +31,6 @@ displaydoc = { workspace = true }
 pretty_env_logger = { workspace = true }
 log = { workspace = true }
 
-fs_extra = { workspace = true }
 dunce = { workspace = true }
 ureq = { workspace = true }
 

--- a/crossbundle/cli/Cargo.toml
+++ b/crossbundle/cli/Cargo.toml
@@ -22,7 +22,6 @@ crossbow = { workspace = true, default-features = false, features = ["update-man
 crossbundle-tools = { workspace = true, default-features = false }
 android-tools = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive"] }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 anyhow = { workspace = true }
@@ -33,7 +32,6 @@ pretty_env_logger = { workspace = true }
 log = { workspace = true }
 
 fs_extra = { workspace = true }
-dirs = { workspace = true }
 dunce = { workspace = true }
 ureq = { workspace = true }
 

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -491,12 +491,8 @@ impl AndroidBuildCommand {
             .arg(&key.key_alias);
         command.output_err(true)?;
 
-        let signed_aab = android_build_dir.join(format!("{}_signed.aab", package_name));
-        std::fs::rename(&aab_path, &signed_aab)?;
-        let output_aab = signed_aab.file_name().unwrap().to_str().unwrap();
-        let aab_output_path = outputs_build_dir.join(output_aab);
-        std::fs::copy(&signed_aab, &aab_output_path)?;
-        std::fs::remove_file(signed_aab)?;
+        let aab_output_path = outputs_build_dir.join(format!("{}_signed.aab", package_name));
+        std::fs::rename(aab_path, &aab_output_path)?;
         config.status("Build finished successfully")?;
         Ok((manifest, sdk.clone(), aab_output_path, package_name, key))
     }

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -495,9 +495,8 @@ impl AndroidBuildCommand {
         std::fs::rename(&aab_path, &signed_aab)?;
         let output_aab = signed_aab.file_name().unwrap().to_str().unwrap();
         let aab_output_path = outputs_build_dir.join(output_aab);
-        let mut options = fs_extra::file::CopyOptions::new();
-        options.overwrite = true;
-        fs_extra::file::move_file(&signed_aab, outputs_build_dir.join(output_aab), &options)?;
+        std::fs::copy(&signed_aab, &aab_output_path)?;
+        std::fs::remove_file(signed_aab)?;
         config.status("Build finished successfully")?;
         Ok((manifest, sdk.clone(), aab_output_path, package_name, key))
     }

--- a/crossbundle/cli/src/commands/install/mod.rs
+++ b/crossbundle/cli/src/commands/install/mod.rs
@@ -95,7 +95,7 @@ pub fn download_to_file(download_url: &str, file_path: &std::path::Path) -> Resu
 
 /// Using default file path related on $HOME path for all installed commands
 pub fn default_file_path(file_name: String) -> Result<std::path::PathBuf> {
-    let default_file_path = dirs::home_dir()
+    let default_file_path = std::env::home_dir()
         .ok_or(Error::HomeDirNotFound)?
         .join(file_name);
     Ok(default_file_path)

--- a/crossbundle/cli/src/error.rs
+++ b/crossbundle/cli/src/error.rs
@@ -33,8 +33,6 @@ pub enum Error {
     /// AndroidManifest error: {0:?}
     #[cfg(feature = "android")]
     AndroidManifest(#[from] android_manifest::error::Error),
-    /// FsExtra error: {0:?}
-    FsExtra(#[from] fs_extra::error::Error),
     /// Path {0:?} doesn't exist
     PathNotFound(std::path::PathBuf),
     /// Home dir not found

--- a/crossbundle/cli/src/error.rs
+++ b/crossbundle/cli/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Display, Debug, Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum Error {
     /// One or more doctor checks failed
     DoctorFailed,

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -72,7 +72,6 @@ semver = { workspace = true }
 toml = { workspace = true }
 
 dunce = { workspace = true }
-fs_extra = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
 image = { workspace = true, default-features = false, features = ["png", "jpeg"] }
 

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -74,7 +74,6 @@ toml = { workspace = true }
 dunce = { workspace = true }
 fs_extra = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
-zip-extensions = { workspace = true, default-features = false }
 image = { workspace = true, default-features = false, features = ["png", "jpeg"] }
 
 thiserror = { workspace = true }

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -68,24 +68,18 @@ android-tools = { workspace = true, optional = true }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_plain = { workspace = true }
 semver = { workspace = true }
 toml = { workspace = true }
 
 dunce = { workspace = true }
 fs_extra = { workspace = true }
-dirs = { workspace = true }
-which = { workspace = true }
-tempfile = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
 zip-extensions = { workspace = true, default-features = false }
 image = { workspace = true, default-features = false, features = ["png", "jpeg"] }
 
-itertools = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 displaydoc = { workspace = true }
-log = { workspace = true }
 termcolor = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -106,7 +100,7 @@ features = [
 ]
 
 [dev-dependencies]
-serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = ["android", "apple"]

--- a/crossbundle/tools/src/commands/android/common/write_zip.rs
+++ b/crossbundle/tools/src/commands/android/common/write_zip.rs
@@ -1,12 +1,39 @@
-use std::path::Path;
-use zip::ZipWriter;
-use zip_extensions::deflate::zip_writer_extensions::ZipWriterExtensions;
+use std::{
+    fs::File,
+    io,
+    path::Path,
+};
+use zip::{ZipWriter, write::SimpleFileOptions};
 
 /// Writing files into archive
 pub fn zip_write(source_path: &Path, archive_file: &Path) -> zip::result::ZipResult<()> {
-    let file = std::fs::File::create(archive_file)?;
+    let file = File::create(archive_file)?;
     let mut zip = ZipWriter::new(file);
-    zip.create_from_directory(&source_path.to_path_buf())?;
+    let mut directories = vec![source_path.to_path_buf()];
+
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            let relative_path = path.strip_prefix(source_path).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("archive entry is outside the source directory: {error}"),
+                )
+            })?;
+            let metadata = entry.metadata()?;
+
+            if metadata.is_dir() {
+                zip.add_directory_from_path(relative_path, SimpleFileOptions::default())?;
+                directories.push(path);
+            } else if metadata.is_file() {
+                zip.start_file_from_path(relative_path, SimpleFileOptions::default())?;
+                let mut source = File::open(path)?;
+                io::copy(&mut source, &mut zip)?;
+            }
+        }
+    }
+
     zip.finish()?;
     Ok(())
 }
@@ -37,8 +64,10 @@ mod tests {
         let source_dir = temp_dir.path().join("module");
         let manifest_dir = source_dir.join("manifest");
         let library_dir = source_dir.join("lib").join("arm64-v8a");
+        let empty_dir = source_dir.join("assets").join("empty");
         std::fs::create_dir_all(&manifest_dir).unwrap();
         std::fs::create_dir_all(&library_dir).unwrap();
+        std::fs::create_dir_all(&empty_dir).unwrap();
         std::fs::write(
             manifest_dir.join("AndroidManifest.xml"),
             b"<manifest package=\"com.crossbow.test\" />",
@@ -67,5 +96,7 @@ mod tests {
             .read_to_end(&mut library)
             .unwrap();
         assert_eq!(library, b"native-library");
+
+        assert!(archive.by_name("assets/empty/").unwrap().is_dir());
     }
 }

--- a/crossbundle/tools/src/commands/android/common/write_zip.rs
+++ b/crossbundle/tools/src/commands/android/common/write_zip.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs::File,
-    io,
-    path::Path,
-};
+use std::{fs::File, io, path::Path};
 use zip::{ZipWriter, write::SimpleFileOptions};
 
 /// Writing files into archive
@@ -39,16 +35,16 @@ pub fn zip_write(source_path: &Path, archive_file: &Path) -> zip::result::ZipRes
 }
 
 /// Moving AndroidManifest.xml file into directory to write files to archive
-pub fn zip_dirs_to_write(source_path: &Path) -> fs_extra::error::Result<()> {
+pub fn zip_dirs_to_write(source_path: &Path) -> io::Result<()> {
     let path = source_path.join("AndroidManifest.xml");
     if path.exists() {
         let manifest_path = source_path.join("manifest");
         if !manifest_path.exists() {
             std::fs::create_dir_all(&manifest_path)?;
         }
-        let mut options = fs_extra::file::CopyOptions::new();
-        options.overwrite = true;
-        fs_extra::file::move_file(&path, manifest_path.join("AndroidManifest.xml"), &options)?;
+        let destination = manifest_path.join("AndroidManifest.xml");
+        std::fs::copy(&path, destination)?;
+        std::fs::remove_file(path)?;
     }
     Ok(())
 }
@@ -98,5 +94,23 @@ mod tests {
         assert_eq!(library, b"native-library");
 
         assert!(archive.by_name("assets/empty/").unwrap().is_dir());
+    }
+
+    #[test]
+    fn zip_dirs_to_write_relocates_and_overwrites_manifest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source_dir = temp_dir.path();
+        let manifest_dir = source_dir.join("manifest");
+        std::fs::create_dir(&manifest_dir).unwrap();
+        std::fs::write(source_dir.join("AndroidManifest.xml"), "new").unwrap();
+        std::fs::write(manifest_dir.join("AndroidManifest.xml"), "old").unwrap();
+
+        zip_dirs_to_write(source_dir).unwrap();
+
+        assert!(!source_dir.join("AndroidManifest.xml").exists());
+        assert_eq!(
+            std::fs::read_to_string(manifest_dir.join("AndroidManifest.xml")).unwrap(),
+            "new"
+        );
     }
 }

--- a/crossbundle/tools/src/commands/android/common/write_zip.rs
+++ b/crossbundle/tools/src/commands/android/common/write_zip.rs
@@ -3,29 +3,31 @@ use zip::{ZipWriter, write::SimpleFileOptions};
 
 /// Writing files into archive
 pub fn zip_write(source_path: &Path, archive_file: &Path) -> zip::result::ZipResult<()> {
-    let file = File::create(archive_file)?;
-    let mut zip = ZipWriter::new(file);
+    let mut zip = ZipWriter::new(File::create(archive_file)?);
     let mut directories = vec![source_path.to_path_buf()];
 
     while let Some(directory) = directories.pop() {
         for entry in std::fs::read_dir(directory)? {
             let entry = entry?;
             let path = entry.path();
-            let relative_path = path.strip_prefix(source_path).map_err(|error| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("archive entry is outside the source directory: {error}"),
-                )
-            })?;
-            let metadata = entry.metadata()?;
+            let relative_path = path
+                .strip_prefix(source_path)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+            let file_type = entry.file_type()?;
 
-            if metadata.is_dir() {
+            if file_type.is_dir() {
                 zip.add_directory_from_path(relative_path, SimpleFileOptions::default())?;
                 directories.push(path);
-            } else if metadata.is_file() {
+            } else if file_type.is_file() {
                 zip.start_file_from_path(relative_path, SimpleFileOptions::default())?;
                 let mut source = File::open(path)?;
                 io::copy(&mut source, &mut zip)?;
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unsupported archive source entry: {}", path.display()),
+                )
+                .into());
             }
         }
     }
@@ -39,12 +41,8 @@ pub fn zip_dirs_to_write(source_path: &Path) -> io::Result<()> {
     let path = source_path.join("AndroidManifest.xml");
     if path.exists() {
         let manifest_path = source_path.join("manifest");
-        if !manifest_path.exists() {
-            std::fs::create_dir_all(&manifest_path)?;
-        }
-        let destination = manifest_path.join("AndroidManifest.xml");
-        std::fs::copy(&path, destination)?;
-        std::fs::remove_file(path)?;
+        std::fs::create_dir_all(&manifest_path)?;
+        std::fs::rename(path, manifest_path.join("AndroidManifest.xml"))?;
     }
     Ok(())
 }
@@ -111,6 +109,25 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(manifest_dir.join("AndroidManifest.xml")).unwrap(),
             "new"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn zip_write_rejects_symlinks() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&source_dir).unwrap();
+        std::fs::write(temp_dir.path().join("target"), "target").unwrap();
+        std::os::unix::fs::symlink(temp_dir.path().join("target"), source_dir.join("symlink"))
+            .unwrap();
+
+        let error = zip_write(&source_dir, &temp_dir.path().join("archive.zip")).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported archive source entry")
         );
     }
 }

--- a/crossbundle/tools/src/commands/android/gradle/gen_gradle_project.rs
+++ b/crossbundle/tools/src/commands/android/gradle/gen_gradle_project.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
 use crate::{
-    commands::CargoProject,
+    commands::{CargoProject, ExistingFile, copy_directory_contents},
     types::{AndroidGradlePlugins, AndroidRuntime, GradleDependencyProject},
 };
 use crossbow_android::embed::CrossbowAndroidAppTemplate;
@@ -68,16 +68,13 @@ pub fn gen_gradle_project(
         get_settings_gradle(&plugins.local_projects)?,
     )?;
 
-    let mut options = fs_extra::dir::CopyOptions::new();
-    options.overwrite = true;
-    options.content_only = true;
     // Copy resources to gradle folder if provided
     if let Some(resources_dir) = resources_dir {
         let path = gradle_project_path.join("res");
         if path.exists() {
             std::fs::remove_dir_all(&path)?;
         }
-        fs_extra::dir::copy(resources_dir, &path, &options)?;
+        copy_directory_contents(resources_dir, &path, ExistingFile::Overwrite)?;
     }
     // Copy assets to gradle folder if provided
     if let Some(assets_dir) = assets_dir {
@@ -85,7 +82,7 @@ pub fn gen_gradle_project(
         if path.exists() {
             std::fs::remove_dir_all(&path)?;
         }
-        fs_extra::dir::copy(assets_dir, &path, &options)?;
+        copy_directory_contents(assets_dir, &path, ExistingFile::Overwrite)?;
     }
 
     Ok(gradle_project_path)

--- a/crossbundle/tools/src/commands/android/gradle/gradle_init.rs
+++ b/crossbundle/tools/src/commands/android/gradle/gradle_init.rs
@@ -9,26 +9,21 @@ use std::{
 pub fn gradle_init() -> Result<Command> {
     let path = std::env::var_os("PATH");
     let gradle_home = std::env::var_os("GRADLE_HOME");
-    Ok(Command::new(find_gradle(
-        path.as_deref(),
-        gradle_home.as_deref(),
-    )?))
+    find_gradle(path.as_deref(), gradle_home.as_deref())
+        .map(Command::new)
+        .ok_or_else(|| AndroidError::GradleNotFound.into())
 }
 
-fn find_gradle(path: Option<&OsStr>, gradle_home: Option<&OsStr>) -> Result<PathBuf> {
-    if let Some(gradle) = path
-        .into_iter()
+fn find_gradle(path: Option<&OsStr>, gradle_home: Option<&OsStr>) -> Option<PathBuf> {
+    path.into_iter()
         .flat_map(std::env::split_paths)
         .map(|directory| directory.join(bat!("gradle")))
         .find(|candidate| is_executable(candidate))
-    {
-        return Ok(gradle);
-    }
-
-    gradle_home
-        .map(PathBuf::from)
-        .map(|home| home.join("bin").join(bat!("gradle")))
-        .ok_or_else(|| AndroidError::GradleNotFound.into())
+        .or_else(|| {
+            gradle_home
+                .map(|home| PathBuf::from(home).join("bin").join(bat!("gradle")))
+                .filter(|candidate| is_executable(candidate))
+        })
 }
 
 #[cfg(unix)]
@@ -69,10 +64,14 @@ mod tests {
     fn gradle_home_is_used_when_path_has_no_gradle() {
         let temp = tempfile::tempdir().unwrap();
         let gradle_home = temp.path().join("gradle-home");
+        let gradle = gradle_home.join("bin").join(bat!("gradle"));
+        std::fs::create_dir_all(gradle.parent().unwrap()).unwrap();
+        std::fs::write(&gradle, "").unwrap();
+        make_executable(&gradle);
 
         assert_eq!(
             find_gradle(None, Some(gradle_home.as_os_str())).unwrap(),
-            gradle_home.join("bin").join(bat!("gradle"))
+            gradle
         );
     }
 

--- a/crossbundle/tools/src/commands/android/gradle/gradle_init.rs
+++ b/crossbundle/tools/src/commands/android/gradle/gradle_init.rs
@@ -1,26 +1,90 @@
 use crate::error::{AndroidError, Result};
-use std::process::Command;
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// Find gradle executable file in and initialize it
 pub fn gradle_init() -> Result<Command> {
-    if let Ok(gradle) = which::which(bat!("gradle")) {
-        return Ok(Command::new(gradle));
+    let path = std::env::var_os("PATH");
+    let gradle_home = std::env::var_os("GRADLE_HOME");
+    Ok(Command::new(find_gradle(
+        path.as_deref(),
+        gradle_home.as_deref(),
+    )?))
+}
+
+fn find_gradle(path: Option<&OsStr>, gradle_home: Option<&OsStr>) -> Result<PathBuf> {
+    if let Some(gradle) = path
+        .into_iter()
+        .flat_map(std::env::split_paths)
+        .map(|directory| directory.join(bat!("gradle")))
+        .find(|candidate| is_executable(candidate))
+    {
+        return Ok(gradle);
     }
-    let gradle = std::env::var("GRADLE_HOME").ok();
-    let gradle_path = std::path::PathBuf::from(gradle.ok_or(AndroidError::GradleNotFound)?);
-    let gradle_executable = gradle_path.join("bin").join(bat!("gradle"));
-    Ok(Command::new(gradle_executable))
+
+    gradle_home
+        .map(PathBuf::from)
+        .map(|home| home.join("bin").join(bat!("gradle")))
+        .ok_or_else(|| AndroidError::GradleNotFound.into())
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.metadata()
+        .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(windows)]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::error::CommandExt;
+    use super::find_gradle;
 
-    use super::gradle_init;
     #[test]
-    fn test_gradle_exe() {
-        let mut gradle = gradle_init().unwrap();
-        gradle.arg("-h");
-        gradle.output_err(true).unwrap();
+    fn path_takes_precedence_over_gradle_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let path_dir = temp.path().join("path/bin");
+        let gradle_home = temp.path().join("gradle-home");
+        std::fs::create_dir_all(&path_dir).unwrap();
+        let path_gradle = path_dir.join(bat!("gradle"));
+        std::fs::write(&path_gradle, "").unwrap();
+        make_executable(&path_gradle);
+
+        let path = std::env::join_paths([&path_dir]).unwrap();
+        assert_eq!(
+            find_gradle(Some(&path), Some(gradle_home.as_os_str())).unwrap(),
+            path_gradle
+        );
     }
+
+    #[test]
+    fn gradle_home_is_used_when_path_has_no_gradle() {
+        let temp = tempfile::tempdir().unwrap();
+        let gradle_home = temp.path().join("gradle-home");
+
+        assert_eq!(
+            find_gradle(None, Some(gradle_home.as_os_str())).unwrap(),
+            gradle_home.join("bin").join(bat!("gradle"))
+        );
+    }
+
+    #[cfg(unix)]
+    fn make_executable(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = path.metadata().unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(windows)]
+    fn make_executable(_path: &std::path::Path) {}
 }

--- a/crossbundle/tools/src/commands/android/native/aab/add_libs_into_aapt2.rs
+++ b/crossbundle/tools/src/commands/android/native/aab/add_libs_into_aapt2.rs
@@ -67,9 +67,7 @@ pub fn add_lib_aapt2(lib_path: &Path, out_dir: &Path, project_dir: &Path) -> Res
         std::fs::create_dir_all(project_dir)?;
     }
     let filename = lib_path.file_name().unwrap();
-    let mut options = fs_extra::file::CopyOptions::new();
-    options.overwrite = true;
-    fs_extra::file::copy(lib_path, out_dir.join(filename), &options)?;
-    fs_extra::file::copy(lib_path, project_dir.join(filename), &options)?;
+    std::fs::copy(lib_path, out_dir.join(filename))?;
+    std::fs::copy(lib_path, project_dir.join(filename))?;
     Ok(())
 }

--- a/crossbundle/tools/src/commands/apple/copy_profile.rs
+++ b/crossbundle/tools/src/commands/apple/copy_profile.rs
@@ -13,7 +13,7 @@ pub fn copy_profile(
     let profile_path = if let Some(path) = profile_path {
         path
     } else if let Some(name) = profile_name {
-        dirs::home_dir()
+        std::env::home_dir()
             .unwrap()
             .join("Library")
             .join("MobileDevice")

--- a/crossbundle/tools/src/commands/apple/gen_app_folder.rs
+++ b/crossbundle/tools/src/commands/apple/gen_app_folder.rs
@@ -1,4 +1,5 @@
-use crate::{commands::ExistingFile, error::*};
+use crate::commands::{ExistingFile, copy_directory_contents};
+use crate::error::*;
 use std::fs::{create_dir_all, remove_dir_all};
 use std::path::{Path, PathBuf};
 
@@ -21,7 +22,7 @@ pub fn gen_apple_app_folder(
         if !resources_dir.exists() {
             return Err(AppleError::ResourcesNotFound.into());
         }
-        crate::commands::copy_directory_contents(resources_dir, &app_path, ExistingFile::Skip)?;
+        copy_directory_contents(resources_dir, &app_path, ExistingFile::Skip)?;
     }
     // Copy assets to app folder if provided
     if let Some(assets_dir) = &assets_dir {
@@ -30,7 +31,7 @@ pub fn gen_apple_app_folder(
         }
         let assets_path = app_path.join("assets");
         create_dir_all(&assets_path)?;
-        crate::commands::copy_directory_contents(assets_dir, &assets_path, ExistingFile::Skip)?;
+        copy_directory_contents(assets_dir, &assets_path, ExistingFile::Skip)?;
     }
     Ok(app_path)
 }

--- a/crossbundle/tools/src/commands/apple/gen_app_folder.rs
+++ b/crossbundle/tools/src/commands/apple/gen_app_folder.rs
@@ -1,5 +1,4 @@
-use crate::error::*;
-use fs_extra::dir::{CopyOptions, copy as copy_dir};
+use crate::{commands::ExistingFile, error::*};
 use std::fs::{create_dir_all, remove_dir_all};
 use std::path::{Path, PathBuf};
 
@@ -17,16 +16,12 @@ pub fn gen_apple_app_folder(
     let app_path = target_dir.join(format!("{}.app", project_name));
     remove_dir_all(&app_path).ok();
     create_dir_all(&app_path)?;
-    // Copy options
-    let mut options = CopyOptions::new();
-    options.skip_exist = true;
-    options.content_only = true;
     // Copy resources to app folder if provided
     if let Some(resources_dir) = &resources_dir {
         if !resources_dir.exists() {
             return Err(AppleError::ResourcesNotFound.into());
         }
-        copy_dir(resources_dir, &app_path, &options)?;
+        crate::commands::copy_directory_contents(resources_dir, &app_path, ExistingFile::Skip)?;
     }
     // Copy assets to app folder if provided
     if let Some(assets_dir) = &assets_dir {
@@ -35,7 +30,7 @@ pub fn gen_apple_app_folder(
         }
         let assets_path = app_path.join("assets");
         create_dir_all(&assets_path)?;
-        copy_dir(assets_dir, &assets_path, &options)?;
+        crate::commands::copy_directory_contents(assets_dir, &assets_path, ExistingFile::Skip)?;
     }
     Ok(app_path)
 }

--- a/crossbundle/tools/src/commands/apple/gen_ipa.rs
+++ b/crossbundle/tools/src/commands/apple/gen_ipa.rs
@@ -1,4 +1,5 @@
-use crate::{commands::ExistingFile, error::*};
+use crate::commands::{ExistingFile, copy_directory_contents};
+use crate::error::*;
 use std::fs::{create_dir_all, remove_dir_all};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -19,7 +20,7 @@ pub fn gen_apple_ipa(target_dir: &Path, app_dir: &Path, project_name: &str) -> R
             format!("app path has no directory name: {}", app_dir.display()),
         )
     })?;
-    crate::commands::copy_directory_contents(
+    copy_directory_contents(
         app_dir,
         &payload_path.join(app_name),
         ExistingFile::Overwrite,

--- a/crossbundle/tools/src/commands/apple/gen_ipa.rs
+++ b/crossbundle/tools/src/commands/apple/gen_ipa.rs
@@ -1,6 +1,6 @@
-use crate::error::*;
-use fs_extra::dir::{CopyOptions, copy as copy_dir};
+use crate::{commands::ExistingFile, error::*};
 use std::fs::{create_dir_all, remove_dir_all};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -13,10 +13,17 @@ pub fn gen_apple_ipa(target_dir: &Path, app_dir: &Path, project_name: &str) -> R
     let payload_path = target_dir.join("Payload");
     remove_dir_all(&payload_path).ok();
     create_dir_all(&payload_path)?;
-    // Copy options
-    let mut options = CopyOptions::new();
-    options.copy_inside = true;
-    copy_dir(app_dir, &payload_path, &options)?;
+    let app_name = app_dir.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("app path has no directory name: {}", app_dir.display()),
+        )
+    })?;
+    crate::commands::copy_directory_contents(
+        app_dir,
+        &payload_path.join(app_name),
+        ExistingFile::Overwrite,
+    )?;
     // Generate result ipa path
     let ipa_file = format!("{}.ipa", project_name);
     let ipa_path = target_dir.join(&ipa_file);

--- a/crossbundle/tools/src/commands/apple/rust_compile.rs
+++ b/crossbundle/tools/src/commands/apple/rust_compile.rs
@@ -40,9 +40,11 @@ pub fn compile_rust_for_ios(
     cargo.args(["--target", triple]);
     if !crate_types.is_empty() {
         // Creates a comma-separated string
-        let crate_types: String =
-            itertools::Itertools::intersperse(crate_types.iter().map(|v| v.as_ref()), ",")
-                .collect();
+        let crate_types = crate_types
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<&str>>()
+            .join(",");
         cargo.args(["--", "--crate-type", &crate_types]);
     };
     cargo.output_err(true)?;

--- a/crossbundle/tools/src/commands/common/combine_folders.rs
+++ b/crossbundle/tools/src/commands/common/combine_folders.rs
@@ -1,7 +1,8 @@
-use crate::error::Result;
-use fs_extra::dir::{CopyOptions, copy as copy_dir};
+use crate::{commands::ExistingFile, error::Result};
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
+
+use super::copy_directory_contents;
 
 /// Place all folders' inner files into output directory.
 pub fn combine_folders(folder_paths: &[PathBuf], output: &Path) -> Result<()> {
@@ -10,12 +11,12 @@ pub fn combine_folders(folder_paths: &[PathBuf], output: &Path) -> Result<()> {
         create_dir_all(output)?;
     }
 
-    // Copy options
-    let mut options = CopyOptions::new();
-    options.overwrite = true;
-    options.content_only = true;
     for folder_path in folder_paths {
-        copy_dir(dunce::simplified(folder_path), output, &options)?;
+        copy_directory_contents(
+            dunce::simplified(folder_path),
+            output,
+            ExistingFile::Overwrite,
+        )?;
     }
     Ok(())
 }

--- a/crossbundle/tools/src/commands/common/combine_folders.rs
+++ b/crossbundle/tools/src/commands/common/combine_folders.rs
@@ -1,8 +1,8 @@
-use crate::{commands::ExistingFile, error::Result};
+use crate::error::Result;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 
-use super::copy_directory_contents;
+use super::{ExistingFile, copy_directory_contents};
 
 /// Place all folders' inner files into output directory.
 pub fn combine_folders(folder_paths: &[PathBuf], output: &Path) -> Result<()> {

--- a/crossbundle/tools/src/commands/common/copy_directory.rs
+++ b/crossbundle/tools/src/commands/common/copy_directory.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     fs, io,
     path::{Path, PathBuf},
 };
@@ -16,64 +15,50 @@ pub(crate) fn copy_directory_contents(
     destination: &Path,
     existing_file: ExistingFile,
 ) -> io::Result<()> {
-    copy_directory_contents_inner(source, destination, existing_file, &mut HashSet::new())
-}
-
-fn copy_directory_contents_inner(
-    source: &Path,
-    destination: &Path,
-    existing_file: ExistingFile,
-    ancestors: &mut HashSet<PathBuf>,
-) -> io::Result<()> {
-    if !source.is_dir() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("source is not a directory: {}", source.display()),
-        ));
-    }
-
-    let canonical_source = fs::canonicalize(source)?;
-    if !ancestors.insert(canonical_source.clone()) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("directory symlink cycle at {}", source.display()),
-        ));
-    }
-
-    fs::create_dir_all(destination)?;
-    let result = (|| {
-        for entry in fs::read_dir(source)? {
-            let entry = entry?;
-            let source_path = entry.path();
-            let destination_path = destination.join(entry.file_name());
-
-            if source_path.is_dir() {
-                copy_directory_contents_inner(
-                    &source_path,
-                    &destination_path,
-                    existing_file,
-                    ancestors,
-                )?;
-            } else if source_path.is_file() {
-                if destination_path.exists() && matches!(existing_file, ExistingFile::Skip) {
-                    continue;
-                }
-                fs::copy(source_path, destination_path)?;
-            } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!(
-                        "source is not a file or directory: {}",
-                        source_path.display()
-                    ),
-                ));
-            }
+    fn copy(
+        source: &Path,
+        destination: &Path,
+        existing_file: ExistingFile,
+        ancestors: &mut Vec<PathBuf>,
+    ) -> io::Result<()> {
+        let canonical_source = fs::canonicalize(source)?;
+        if ancestors.contains(&canonical_source) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("directory symlink cycle at {}", source.display()),
+            ));
         }
-        Ok(())
-    })();
+        let entries = fs::read_dir(source)?;
+        ancestors.push(canonical_source);
 
-    ancestors.remove(&canonical_source);
-    result
+        let result = (|| {
+            fs::create_dir_all(destination)?;
+            for entry in entries {
+                let entry = entry?;
+                let source = entry.path();
+                let destination = destination.join(entry.file_name());
+                let metadata = fs::metadata(&source)?;
+
+                if metadata.is_dir() {
+                    copy(&source, &destination, existing_file, ancestors)?;
+                } else if !metadata.is_file() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("source is not a file or directory: {}", source.display()),
+                    ));
+                } else if !destination.exists() || matches!(existing_file, ExistingFile::Overwrite)
+                {
+                    fs::copy(source, destination)?;
+                }
+            }
+            Ok(())
+        })();
+
+        ancestors.pop();
+        result
+    }
+
+    copy(source, destination, existing_file, &mut Vec::new())
 }
 
 #[cfg(test)]

--- a/crossbundle/tools/src/commands/common/copy_directory.rs
+++ b/crossbundle/tools/src/commands/common/copy_directory.rs
@@ -1,0 +1,140 @@
+use std::{
+    collections::HashSet,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Copy)]
+pub(crate) enum ExistingFile {
+    Overwrite,
+    #[cfg_attr(not(feature = "apple"), allow(dead_code))]
+    Skip,
+}
+
+pub(crate) fn copy_directory_contents(
+    source: &Path,
+    destination: &Path,
+    existing_file: ExistingFile,
+) -> io::Result<()> {
+    copy_directory_contents_inner(source, destination, existing_file, &mut HashSet::new())
+}
+
+fn copy_directory_contents_inner(
+    source: &Path,
+    destination: &Path,
+    existing_file: ExistingFile,
+    ancestors: &mut HashSet<PathBuf>,
+) -> io::Result<()> {
+    if !source.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("source is not a directory: {}", source.display()),
+        ));
+    }
+
+    let canonical_source = fs::canonicalize(source)?;
+    if !ancestors.insert(canonical_source.clone()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("directory symlink cycle at {}", source.display()),
+        ));
+    }
+
+    fs::create_dir_all(destination)?;
+    let result = (|| {
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let source_path = entry.path();
+            let destination_path = destination.join(entry.file_name());
+
+            if source_path.is_dir() {
+                copy_directory_contents_inner(
+                    &source_path,
+                    &destination_path,
+                    existing_file,
+                    ancestors,
+                )?;
+            } else if source_path.is_file() {
+                if destination_path.exists() && matches!(existing_file, ExistingFile::Skip) {
+                    continue;
+                }
+                fs::copy(source_path, destination_path)?;
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "source is not a file or directory: {}",
+                        source_path.display()
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    })();
+
+    ancestors.remove(&canonical_source);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copies_nested_contents_and_empty_directories() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = temp_dir.path().join("source");
+        let destination = temp_dir.path().join("destination");
+        fs::create_dir_all(source.join("nested/empty")).unwrap();
+        fs::write(source.join("nested/value.txt"), "new").unwrap();
+        fs::create_dir_all(destination.join("nested")).unwrap();
+        fs::write(destination.join("nested/value.txt"), "old").unwrap();
+
+        copy_directory_contents(&source, &destination, ExistingFile::Overwrite).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("nested/value.txt")).unwrap(),
+            "new"
+        );
+        assert!(destination.join("nested/empty").is_dir());
+    }
+
+    #[test]
+    fn can_skip_existing_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = temp_dir.path().join("source");
+        let destination = temp_dir.path().join("destination");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&destination).unwrap();
+        fs::write(source.join("existing.txt"), "new").unwrap();
+        fs::write(source.join("additional.txt"), "additional").unwrap();
+        fs::write(destination.join("existing.txt"), "old").unwrap();
+
+        copy_directory_contents(&source, &destination, ExistingFile::Skip).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("existing.txt")).unwrap(),
+            "old"
+        );
+        assert_eq!(
+            fs::read_to_string(destination.join("additional.txt")).unwrap(),
+            "additional"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_directory_symlink_cycles() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = temp_dir.path().join("source");
+        let destination = temp_dir.path().join("destination");
+        fs::create_dir_all(source.join("nested")).unwrap();
+        std::os::unix::fs::symlink(&source, source.join("nested/back")).unwrap();
+
+        let error =
+            copy_directory_contents(&source, &destination, ExistingFile::Overwrite).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("symlink cycle"));
+    }
+}

--- a/crossbundle/tools/src/commands/common/mod.rs
+++ b/crossbundle/tools/src/commands/common/mod.rs
@@ -2,12 +2,14 @@
 
 mod cargo_project;
 mod combine_folders;
+mod copy_directory;
 mod create_project;
 mod find_cargo_manifest_path;
 mod gen_minimal_project;
 
 pub use cargo_project::*;
 pub use combine_folders::*;
+pub(crate) use copy_directory::*;
 pub use create_project::*;
 pub use find_cargo_manifest_path::*;
 pub use gen_minimal_project::*;

--- a/crossbundle/tools/src/error.rs
+++ b/crossbundle/tools/src/error.rs
@@ -124,8 +124,6 @@ pub enum Error {
     FailedToChooseShellStringColor(String),
     /// IO error: {0:?}
     Io(#[from] std::io::Error),
-    /// FS Extra error: {0:?}
-    FsExtra(#[from] fs_extra::error::Error),
     /// Zip error: {0:?}
     Zip(#[from] zip::result::ZipError),
     /// Android error: {0:?}

--- a/crossbundle/tools/src/toolchain/doctor.rs
+++ b/crossbundle/tools/src/toolchain/doctor.rs
@@ -1269,7 +1269,7 @@ fn rust_sysroot(environment: &Environment, project_dir: &Path) -> Option<PathBuf
         .variables
         .get("RUSTUP_HOME")
         .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|home| home.join(".rustup")))?;
+        .or_else(|| std::env::home_dir().map(|home| home.join(".rustup")))?;
     let toolchain = environment
         .variables
         .get("RUSTUP_TOOLCHAIN")

--- a/platform/android/Cargo.toml
+++ b/platform/android/Cargo.toml
@@ -19,10 +19,9 @@ rust-embed = { workspace = true, features = ["include-exclude"], optional = true
 
 jni = { workspace = true, optional = true }
 ndk-context = { workspace = true, optional = true }
-lazy_static = { workspace = true, optional = true }
 async-channel = { workspace = true, optional = true }
 
 [features]
 default = ["android"]
-android = ["jni", "ndk-context", "lazy_static", "async-channel"]
+android = ["jni", "ndk-context", "async-channel"]
 embed = ["rust-embed"]

--- a/platform/android/src/externs/crossbow_lib.rs
+++ b/platform/android/src/externs/crossbow_lib.rs
@@ -7,9 +7,7 @@ use jni::{
 };
 use std::sync::Mutex;
 
-lazy_static::lazy_static! {
-    static ref JAVA_ACTIVITY: Mutex<Option<Global<JObject<'static>>>> = Mutex::new(None);
-}
+static JAVA_ACTIVITY: Mutex<Option<Global<JObject<'static>>>> = Mutex::new(None);
 
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]

--- a/platform/android/src/permission/mod.rs
+++ b/platform/android/src/permission/mod.rs
@@ -9,9 +9,7 @@ use std::sync::{
     mpsc::{SyncSender, sync_channel},
 };
 
-lazy_static::lazy_static! {
-    static ref PERMISSION_SENDER: RwLock<Option<SyncSender<RequestPermissionResult>>> = Default::default();
-}
+static PERMISSION_SENDER: RwLock<Option<SyncSender<RequestPermissionResult>>> = RwLock::new(None);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RequestPermissionResult {

--- a/platform/android/src/plugin/mod.rs
+++ b/platform/android/src/plugin/mod.rs
@@ -11,7 +11,7 @@ use crate::error::*;
 use jni::JavaVM;
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
 
 pub trait CrossbowPlugin {
@@ -22,10 +22,10 @@ pub trait CrossbowPlugin {
     fn get_receiver(&self) -> &Receiver<Signal>;
 }
 
-lazy_static::lazy_static! {
-    static ref JNI_SINGLETONS: Mutex<HashMap<String, Arc<JniSingleton>>> = Default::default();
-    static ref JNI_SIGNAL_SENDERS: Mutex<HashMap<String, Sender<Signal>>> = Default::default();
-}
+static JNI_SINGLETONS: LazyLock<Mutex<HashMap<String, Arc<JniSingleton>>>> =
+    LazyLock::new(Default::default);
+static JNI_SIGNAL_SENDERS: LazyLock<Mutex<HashMap<String, Sender<Signal>>>> =
+    LazyLock::new(Default::default);
 
 fn insert_jni_singleton(
     singleton_name: &str,


### PR DESCRIPTION
## Summary
- replace `lazy_static`, `dirs`, `which`, and `itertools` with stable standard-library APIs
- replace `zip-extensions` and `fs_extra` with focused filesystem helpers
- remove unused dependencies and keep `tempfile` test-only

This reduces dependency surface while preserving bundle behavior. Filesystem moves are atomic, recursive copies reject cycles, and ZIP inputs reject unsupported entries.

## Validation
- all GitHub Actions checks pass, including Windows, Ubuntu, macOS, Docker, Android, Clippy, docs, and dependency policy
- host-compatible workspace test compilation
- standard and Apple test suites
- Windows cross-check for `crossbundle-tools`