### PR TITLE
Harden Apple doctor target and SDK contracts

### DIFF
--- a/crossbundle/tools/src/toolchain/doctor.rs
+++ b/crossbundle/tools/src/toolchain/doctor.rs
@@ -1307,19 +1307,19 @@ fn rust_sysroot(environment: &Environment, project_dir: &Path) -> Option<PathBuf
 
 fn project_toolchain(project_dir: &Path) -> Option<String> {
     project_dir.ancestors().find_map(|directory| {
-        let modern = directory.join("rust-toolchain.toml");
-        if modern.is_file() {
+        let toml_file = directory.join("rust-toolchain.toml");
+        if toml_file.is_file() {
             let value =
-                toml::from_str::<toml::Value>(&std::fs::read_to_string(modern).ok()?).ok()?;
+                toml::from_str::<toml::Value>(&std::fs::read_to_string(toml_file).ok()?).ok()?;
             return value
                 .get("toolchain")?
                 .get("channel")?
                 .as_str()
                 .map(str::to_owned);
         }
-        let legacy = directory.join("rust-toolchain");
-        if legacy.is_file() {
-            std::fs::read_to_string(legacy)
+        let plain_file = directory.join("rust-toolchain");
+        if plain_file.is_file() {
+            std::fs::read_to_string(plain_file)
                 .ok()
                 .map(|value| value.trim().to_owned())
         } else {
@@ -1479,6 +1479,7 @@ mod tests {
     use super::*;
     #[cfg(feature = "android")]
     use std::fs;
+
     #[test]
     fn report_is_sorted_and_json_is_versioned() {
         let report = diagnose(&DoctorRequest::default(), &Environment::default());
@@ -1596,7 +1597,9 @@ release_build_targets = ["not-an-apple-target"]
 
     #[cfg(feature = "apple")]
     #[test]
-    fn apple_json_envelope_and_stable_host_ids_are_golden() {
+    fn apple_json_envelope_and_host_ids_are_stable() {
+        use crate::types::IntoRustTriple as _;
+
         let report = diagnose(
             &DoctorRequest {
                 strict: true,
@@ -1622,25 +1625,26 @@ release_build_targets = ["not-an-apple-target"]
         let ids = report
             .checks
             .iter()
-            .map(|check| check.id.as_str())
+            .map(|check| check.id.clone())
             .collect::<Vec<_>>();
+        let simulator_target = crate::types::IosTarget::host_simulator().rust_triple();
         assert_eq!(
             ids,
             vec![
-                "apple.host.os",
-                "apple.rust.target.aarch64-apple-ios-sim",
-                "apple.sdk.iphoneos",
-                "apple.sdk.iphonesimulator",
-                "apple.signing.identity",
-                "apple.tool.simctl",
-                "apple.tool.xcodebuild",
-                "apple.tool.xcrun",
-                "apple.xcode.command_line_tools",
-                "apple.xcode.developer_dir",
-                "apple.xcode.installation",
-                "apple.xcode.version",
-                "host.rust.cargo",
-                "host.rust.rustc",
+                "apple.host.os".into(),
+                format!("apple.rust.target.{simulator_target}"),
+                "apple.sdk.iphoneos".into(),
+                "apple.sdk.iphonesimulator".into(),
+                "apple.signing.identity".into(),
+                "apple.tool.simctl".into(),
+                "apple.tool.xcodebuild".into(),
+                "apple.tool.xcrun".into(),
+                "apple.xcode.command_line_tools".into(),
+                "apple.xcode.developer_dir".into(),
+                "apple.xcode.installation".into(),
+                "apple.xcode.version".into(),
+                "host.rust.cargo".into(),
+                "host.rust.rustc".into(),
             ]
         );
     }

--- a/crossbundle/tools/src/toolchain/doctor/apple.rs
+++ b/crossbundle/tools/src/toolchain/doctor/apple.rs
@@ -1,11 +1,13 @@
 use super::*;
-use crate::types::IntoRustTriple;
+use crate::types::{IntoRustTriple, IosTarget};
 use std::process::Command;
 
 const DEVELOPER_DIR_ID: &str = "apple.xcode.developer_dir";
 const COMMAND_LINE_TOOLS_ID: &str = "apple.xcode.command_line_tools";
 const SIMCTL_ID: &str = "apple.tool.simctl";
 const SIGNING_IDENTITY_ID: &str = "apple.signing.identity";
+const IPHONEOS_SDK_VERSION: &str = "apple.sdk.iphoneos.version";
+const IPHONESIMULATOR_SDK_VERSION: &str = "apple.sdk.iphonesimulator.version";
 const READ_ONLY_COMMANDS: &[(&str, &str, &[&str])] = &[
     (DEVELOPER_DIR_ID, "xcode-select", &["--print-path"]),
     ("apple.xcode.version", "xcodebuild", &["-version"]),
@@ -20,6 +22,16 @@ const READ_ONLY_COMMANDS: &[(&str, &str, &[&str])] = &[
         "apple.sdk.iphonesimulator",
         "xcrun",
         &["--sdk", "iphonesimulator", "--show-sdk-path"],
+    ),
+    (
+        IPHONEOS_SDK_VERSION,
+        "xcrun",
+        &["--sdk", "iphoneos", "--show-sdk-version"],
+    ),
+    (
+        IPHONESIMULATOR_SDK_VERSION,
+        "xcrun",
+        &["--sdk", "iphonesimulator", "--show-sdk-version"],
     ),
 ];
 const SIGNING_COMMAND: (&str, &str, &[&str]) = (
@@ -101,8 +113,20 @@ pub(super) fn checks(
             "xcrun",
         ),
         command_path_check(environment, SIMCTL_ID, "simctl"),
-        sdk_check(environment, "apple.sdk.iphoneos", "iPhoneOS"),
-        sdk_check(environment, "apple.sdk.iphonesimulator", "iPhoneSimulator"),
+        sdk_check(
+            environment,
+            "apple.sdk.iphoneos",
+            IPHONEOS_SDK_VERSION,
+            "iPhoneOS",
+            request.strict,
+        ),
+        sdk_check(
+            environment,
+            "apple.sdk.iphonesimulator",
+            IPHONESIMULATOR_SDK_VERSION,
+            "iPhoneSimulator",
+            request.strict,
+        ),
     ];
     checks.extend(rust_target_checks(request, environment, false, project));
     checks.push(signing_identity_check(environment, request, project));
@@ -345,19 +369,41 @@ fn executable_file(path: &Path) -> bool {
     }
 }
 
-fn sdk_check(environment: &Environment, id: &str, label: &str) -> DoctorCheck {
+fn sdk_check(
+    environment: &Environment,
+    id: &str,
+    version_id: &str,
+    label: &str,
+    strict: bool,
+) -> DoctorCheck {
     let path = command_path(environment, id).filter(|path| path.is_dir());
-    let version = path
-        .as_ref()
-        .and_then(|path| version_in_text(path.to_string_lossy().as_ref()));
-    required_path_check(
+    let version = successful_command(environment, version_id)
+        .and_then(|output| version_in_text(&output.stdout));
+    let mut result = required_path_check(
         id,
         path,
         version,
         format!("Found the installed {label} SDK"),
         format!("The {label} SDK was not found"),
         format!("Install {label} platform support in Xcode"),
-    )
+    );
+    if result
+        .found
+        .as_ref()
+        .is_some_and(|found| found.version.is_none())
+    {
+        result.status = if strict {
+            CheckStatus::Fail
+        } else {
+            CheckStatus::Warn
+        };
+        result.summary = format!("The {label} SDK version could not be determined");
+        result.remediation = Some(format!(
+            "Ensure xcrun --sdk {} --show-sdk-version succeeds",
+            label.to_ascii_lowercase()
+        ));
+    }
+    result
 }
 
 fn required_path_check(
@@ -413,7 +459,7 @@ fn rust_target_checks(
             .map(|metadata| apple_targets(metadata).map(str::to_owned).collect())
             .unwrap_or_default();
         if targets.is_empty() {
-            targets.push("aarch64-apple-ios-sim".into());
+            targets.push(IosTarget::host_simulator().rust_triple().into());
         }
     }
     targets.sort();
@@ -635,7 +681,7 @@ fn project_checks(context: &project::ProjectContext) -> Vec<DoctorCheck> {
     ];
     let mut targets = apple_targets(metadata).collect::<Vec<_>>();
     if targets.is_empty() {
-        targets.push("aarch64-apple-ios-sim");
+        targets.push(IosTarget::host_simulator().rust_triple());
     }
     targets.sort_unstable();
     targets.dedup();
@@ -851,6 +897,8 @@ mod tests {
                 "apple.sdk.iphonesimulator",
                 simulator_sdk.display().to_string(),
             ),
+            (IPHONEOS_SDK_VERSION, "18.5".into()),
+            (IPHONESIMULATOR_SDK_VERSION, "18.5".into()),
         ]
         .into_iter()
         .map(|(id, stdout)| {
@@ -895,6 +943,40 @@ mod tests {
         ] {
             let check = report.checks.iter().find(|check| check.id == id).unwrap();
             assert_eq!(check.status, CheckStatus::Pass, "{id}: {check:?}");
+        }
+        for id in ["apple.sdk.iphoneos", "apple.sdk.iphonesimulator"] {
+            assert_eq!(
+                report
+                    .checks
+                    .iter()
+                    .find(|check| check.id == id)
+                    .unwrap()
+                    .found
+                    .as_ref()
+                    .and_then(|found| found.version.as_deref()),
+                Some("18.5")
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_sdk_version_warns_or_fails_in_strict_mode() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut environment = fixture_environment(temp.path(), "16.4");
+        environment.commands.remove(IPHONEOS_SDK_VERSION);
+
+        for (strict, status) in [(false, CheckStatus::Warn), (true, CheckStatus::Fail)] {
+            assert_eq!(
+                sdk_check(
+                    &environment,
+                    "apple.sdk.iphoneos",
+                    IPHONEOS_SDK_VERSION,
+                    "iPhoneOS",
+                    strict,
+                )
+                .status,
+                status
+            );
         }
     }
 
@@ -1420,6 +1502,16 @@ icon = "icon-directory"
                 "apple.sdk.iphonesimulator",
                 "xcrun",
                 &["--sdk", "iphonesimulator", "--show-sdk-path"],
+            ),
+            (
+                IPHONEOS_SDK_VERSION,
+                "xcrun",
+                &["--sdk", "iphoneos", "--show-sdk-version"],
+            ),
+            (
+                IPHONESIMULATOR_SDK_VERSION,
+                "xcrun",
+                &["--sdk", "iphonesimulator", "--show-sdk-version"],
             ),
         ];
         assert_eq!(READ_ONLY_COMMANDS, expected);

--- a/docs/src/crossbundle/command-doctor.md
+++ b/docs/src/crossbundle/command-doctor.md
@@ -49,11 +49,13 @@ Gradle plugins.
 
 Apple checks cover the host OS, full Xcode installation, active developer directory,
 Xcode version, Command Line Tools, `xcodebuild`, `xcrun`, `simctl`, iPhoneOS and
-iPhoneSimulator SDKs, relevant installed Rust targets, and signing relevance. Project
-checks use the same typed metadata and Info.plist model as Apple builds to validate bundle
-metadata, bundle identifiers, deployment targets, Rust targets, assets, resources, icons,
-platform-specific plugin compatibility, and signing configuration applicability. Signing
-values and command output that may identify credentials are never included in reports.
+iPhoneSimulator SDK paths and versions, relevant installed Rust targets, and signing
+relevance. Without a project, doctor checks the simulator target matching the Mac's
+architecture (`aarch64-apple-ios-sim` on Apple Silicon or `x86_64-apple-ios` on Intel).
+Project checks use the same typed metadata and Info.plist model as Apple builds to validate
+bundle metadata, bundle identifiers, deployment targets, Rust targets, assets, resources,
+icons, platform-specific plugin compatibility, and signing configuration applicability.
+Signing values and command output that may identify credentials are never included in reports.
 Configured Android Gradle plugins are reported as inapplicable to Apple; ordinary Cargo
 dependencies are not guessed to be plugins. The typed Apple project model has no
 project-level signing fields: `project.apple.signing` warns when a device target requires


### PR DESCRIPTION
## Summary

- make project-independent Apple diagnostics use the same host-architecture simulator target as Apple execution
- discover iPhoneOS and iPhoneSimulator SDK versions with read-only `xcrun --show-sdk-version` probes
- warn when an installed SDK version is unknown and fail that check under `--strict`
- keep Rustup support clear by naming the two supported toolchain-file formats precisely

## Validation

- `cargo fmt --all -- --check`
- all-target, all-feature Clippy with warnings denied
- complete Apple-only `crossbundle-tools` and `crossbundle` test suites
- Android-only, Apple-only, and combined doctor feature checks
- focused SDK discovery, strictness, JSON/ID contract, and read-only command tests
- packaged-crate contents checked
