### PR TITLE
Support allow-listed build variables in platform manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "thiserror 2.0.20",
  "toml",
  "winapi",
+ "xml-rs",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde = "1.0"
 serde_json = "1.0"
 semver = "1.0"
 toml = "1.1"
+xml-rs = "0.8"
 simctl = { version = "0.1.1", package = "creator-simctl" }
 tempfile = "3.27"
 termcolor = "1.4"

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -204,11 +204,7 @@ impl AndroidBuildCommand {
         gradle_manifest.package = None;
         gradle_manifest.version_code = None;
         gradle_manifest.version_name = None;
-        save_android_manifest_with_variables(
-            &gradle_project_path,
-            &gradle_manifest,
-            &context.config.build_variables,
-        )?;
+        save_android_manifest(&gradle_project_path, &gradle_manifest)?;
 
         self.build_rust_lib(config, context, &library_name, Some(android_build_dir), ndk)?;
 
@@ -294,11 +290,7 @@ impl AndroidBuildCommand {
         config.status_message("Reading", "AndroidManifest.xml")?;
         let manifest = Self::get_android_manifest(context, AndroidStrategy::NativeApk)?;
         config.status_message("Generating", "AndroidManifest.xml")?;
-        let manifest_path = save_android_manifest_with_variables(
-            &native_build_dir,
-            &manifest,
-            &context.config.build_variables,
-        )?;
+        let manifest_path = save_android_manifest(&native_build_dir, &manifest)?;
         config.status("Preparing resources and assets")?;
         let (assets, resources) =
             Self::prepare_assets_and_resources(&context.config, &android_build_dir)?;
@@ -387,11 +379,7 @@ impl AndroidBuildCommand {
         config.status_message("Reading", "AndroidManifest.xml")?;
         let manifest = Self::get_android_manifest(context, AndroidStrategy::NativeAab)?;
         config.status_message("Generating", "AndroidManifest.xml")?;
-        let manifest_path = save_android_manifest_with_variables(
-            &native_build_dir,
-            &manifest,
-            &context.config.build_variables,
-        )?;
+        let manifest_path = save_android_manifest(&native_build_dir, &manifest)?;
         config.status("Preparing resources and assets")?;
         let (assets, resources) =
             Self::prepare_assets_and_resources(&context.config, &android_build_dir)?;
@@ -648,7 +636,7 @@ impl AndroidBuildCommand {
         strategy: AndroidStrategy,
     ) -> Result<AndroidManifest> {
         let mut manifest = if let Some(manifest_path) = &context.config.android.manifest_path {
-            read_android_manifest_with_variables(manifest_path, &context.config.build_variables)?
+            read_android_manifest_with_variables(manifest_path, context.config.build_variables())?
         } else if let Some(manifest) = &context.config.android.manifest {
             manifest.clone()
         } else {

--- a/crossbundle/cli/src/commands/build/android.rs
+++ b/crossbundle/cli/src/commands/build/android.rs
@@ -204,7 +204,11 @@ impl AndroidBuildCommand {
         gradle_manifest.package = None;
         gradle_manifest.version_code = None;
         gradle_manifest.version_name = None;
-        save_android_manifest(&gradle_project_path, &gradle_manifest)?;
+        save_android_manifest_with_variables(
+            &gradle_project_path,
+            &gradle_manifest,
+            &context.config.build_variables,
+        )?;
 
         self.build_rust_lib(config, context, &library_name, Some(android_build_dir), ndk)?;
 
@@ -290,7 +294,11 @@ impl AndroidBuildCommand {
         config.status_message("Reading", "AndroidManifest.xml")?;
         let manifest = Self::get_android_manifest(context, AndroidStrategy::NativeApk)?;
         config.status_message("Generating", "AndroidManifest.xml")?;
-        let manifest_path = save_android_manifest(&native_build_dir, &manifest)?;
+        let manifest_path = save_android_manifest_with_variables(
+            &native_build_dir,
+            &manifest,
+            &context.config.build_variables,
+        )?;
         config.status("Preparing resources and assets")?;
         let (assets, resources) =
             Self::prepare_assets_and_resources(&context.config, &android_build_dir)?;
@@ -379,7 +387,11 @@ impl AndroidBuildCommand {
         config.status_message("Reading", "AndroidManifest.xml")?;
         let manifest = Self::get_android_manifest(context, AndroidStrategy::NativeAab)?;
         config.status_message("Generating", "AndroidManifest.xml")?;
-        let manifest_path = save_android_manifest(&native_build_dir, &manifest)?;
+        let manifest_path = save_android_manifest_with_variables(
+            &native_build_dir,
+            &manifest,
+            &context.config.build_variables,
+        )?;
         config.status("Preparing resources and assets")?;
         let (assets, resources) =
             Self::prepare_assets_and_resources(&context.config, &android_build_dir)?;
@@ -636,7 +648,7 @@ impl AndroidBuildCommand {
         strategy: AndroidStrategy,
     ) -> Result<AndroidManifest> {
         let mut manifest = if let Some(manifest_path) = &context.config.android.manifest_path {
-            read_android_manifest(manifest_path)?
+            read_android_manifest_with_variables(manifest_path, &context.config.build_variables)?
         } else if let Some(manifest) = &context.config.android.manifest {
             manifest.clone()
         } else {

--- a/crossbundle/cli/src/commands/build/mod.rs
+++ b/crossbundle/cli/src/commands/build/mod.rs
@@ -27,13 +27,13 @@ pub enum BuildCommand {
 }
 
 impl BuildCommand {
-    pub fn handle_command(&self, config: &Config) -> Result<()> {
+    pub fn handle_command(&self, _config: &Config) -> Result<()> {
         #[cfg(any(feature = "android", feature = "apple"))]
         match &self {
             #[cfg(feature = "android")]
-            Self::Android(cmd) => cmd.run(config)?,
+            Self::Android(cmd) => cmd.run(_config)?,
             #[cfg(feature = "apple")]
-            Self::Ios(cmd) => cmd.run(config)?,
+            Self::Ios(cmd) => cmd.run(_config)?,
         }
         Ok(())
     }

--- a/crossbundle/cli/src/commands/run/mod.rs
+++ b/crossbundle/cli/src/commands/run/mod.rs
@@ -19,13 +19,13 @@ pub enum RunCommand {
 }
 
 impl RunCommand {
-    pub fn handle_command(&self, config: &Config) -> Result<()> {
+    pub fn handle_command(&self, _config: &Config) -> Result<()> {
         #[cfg(any(feature = "android", feature = "apple"))]
         match &self {
             #[cfg(feature = "android")]
-            Self::Android(cmd) => cmd.run(config)?,
+            Self::Android(cmd) => cmd.run(_config)?,
             #[cfg(feature = "apple")]
-            Self::Ios(cmd) => cmd.run(config)?,
+            Self::Ios(cmd) => cmd.run(_config)?,
         }
         Ok(())
     }

--- a/crossbundle/cli/src/lib.rs
+++ b/crossbundle/cli/src/lib.rs
@@ -84,7 +84,9 @@ fn handle_error_source(source: Option<&(dyn std::error::Error + 'static)>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Opts, commands};
+    use super::Opts;
+    #[cfg(any(feature = "android", feature = "apple"))]
+    use super::commands;
     use clap::{CommandFactory, Parser};
     #[cfg(any(feature = "android", feature = "apple"))]
     use crossbundle_tools::toolchain::{DoctorPlatform, resolve_platforms};

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -70,6 +70,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 semver = { workspace = true }
 toml = { workspace = true }
+xml-rs = { workspace = true }
 
 dunce = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -70,7 +70,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 semver = { workspace = true }
 toml = { workspace = true }
-xml-rs = { workspace = true }
+xml-rs = { workspace = true, optional = true }
 
 dunce = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
@@ -103,5 +103,5 @@ tempfile = { workspace = true }
 
 [features]
 default = ["android", "apple"]
-android = ["android-manifest", "android-tools"]
+android = ["android-manifest", "android-tools", "dep:xml-rs"]
 apple = ["apple-bundle", "simctl", "crossbow/update-manifest"]

--- a/crossbundle/tools/src/commands/android/common/read_manifest.rs
+++ b/crossbundle/tools/src/commands/android/common/read_manifest.rs
@@ -1,18 +1,17 @@
 use crate::{
     error::{AndroidError, Result},
-    types::{BuildVariables, interpolate_json_build_variables, interpolate_typed_build_variables},
+    types::{BuildVariables, interpolate_string},
 };
 use android_manifest::AndroidManifest;
 use std::{fs::File, io::BufReader, path::Path};
+use xml::{reader::XmlEvent as ReaderEvent, writer::XmlEvent as WriterEvent};
 
 /// Reads and deserializes `AndroidManifest.xml`.
 pub fn read_android_manifest(path: &Path) -> Result<AndroidManifest> {
     read_android_manifest_with_variables(path, &BuildVariables::default())
 }
 
-/// Reads an Android manifest and expands declared Crossbow build variables in its typed XML
-/// attributes. Resolving after XML parsing lets the manifest serializer safely escape arbitrary
-/// variable values when the generated manifest is written.
+/// Reads an Android manifest after expanding allow-listed variables with XML-aware escaping.
 pub fn read_android_manifest_with_variables(
     path: &Path,
     variables: &BuildVariables,
@@ -20,24 +19,11 @@ pub fn read_android_manifest_with_variables(
     let file = File::open(path).map_err(|_| {
         AndroidError::FailedToFindAndroidManifest(path.to_string_lossy().to_string())
     })?;
-    let reader = BufReader::new(&file);
-    let xml = transform_typed_xml_variables(reader, variables)?;
-    let manifest = android_manifest::from_reader(xml.as_slice()).map_err(AndroidError::from)?;
-    if !xml
-        .windows("{{crossbow.".len())
-        .any(|window| window == b"{{crossbow.")
-    {
-        return Ok(manifest);
-    }
-    interpolate_android_manifest(manifest, variables)
+    let xml = interpolate_xml(BufReader::new(file), variables)?;
+    Ok(android_manifest::from_reader(xml.as_slice()).map_err(AndroidError::from)?)
 }
 
-fn transform_typed_xml_variables(
-    reader: impl std::io::Read,
-    variables: &BuildVariables,
-) -> Result<Vec<u8>> {
-    use xml::{reader::XmlEvent as ReaderEvent, writer::XmlEvent as WriterEvent};
-
+fn interpolate_xml(reader: impl std::io::Read, variables: &BuildVariables) -> Result<Vec<u8>> {
     let mut output = Vec::new();
     let mut writer = xml::EmitterConfig::new()
         .perform_indent(false)
@@ -47,52 +33,29 @@ fn transform_typed_xml_variables(
         match &mut event {
             ReaderEvent::StartElement { attributes, .. } => {
                 for attribute in attributes {
-                    attribute.value =
-                        interpolate_typed_build_variables(&attribute.value, variables)?;
-                }
-                writer
-                    .write(
-                        event
-                            .as_writer_event()
-                            .expect("start elements are writable"),
-                    )
-                    .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
-            }
-            ReaderEvent::Characters(value) => {
-                let value = interpolate_typed_build_variables(value, variables)?;
-                writer
-                    .write(WriterEvent::characters(&value))
-                    .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
-            }
-            ReaderEvent::CData(value) => {
-                let value = interpolate_typed_build_variables(value, variables)?;
-                writer
-                    .write(WriterEvent::cdata(&value))
-                    .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
-            }
-            _ => {
-                if let Some(event) = event.as_writer_event() {
-                    writer.write(event).map_err(|error| {
-                        anyhow::anyhow!("failed to rewrite Android XML: {error}")
-                    })?;
+                    let value = interpolate_string(&attribute.value, variables)?;
+                    attribute.value = xml::escape::escape_str_attribute(&value).into_owned();
                 }
             }
+            ReaderEvent::Characters(value) | ReaderEvent::CData(value) => {
+                let interpolated = interpolate_string(value, variables)?;
+                *value = xml::escape::escape_str_pcdata(&interpolated).into_owned();
+            }
+            _ => {}
+        }
+        let event = match &event {
+            ReaderEvent::Characters(value) => Some(WriterEvent::characters(value)),
+            ReaderEvent::CData(value) => Some(WriterEvent::characters(value)),
+            _ => event.as_writer_event(),
+        };
+        if let Some(event) = event {
+            writer
+                .write(event)
+                .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
         }
     }
     drop(writer);
     Ok(output)
-}
-
-fn interpolate_android_manifest(
-    manifest: AndroidManifest,
-    variables: &BuildVariables,
-) -> Result<AndroidManifest> {
-    let mut value = serde_json::to_value(manifest)
-        .map_err(|error| anyhow::anyhow!("failed to inspect Android manifest: {error}"))?;
-    interpolate_json_build_variables(&mut value, variables)?;
-    crate::types::normalize_android_manifest_json(&mut value);
-    serde_json::from_value(value)
-        .map_err(|error| anyhow::anyhow!("invalid resolved Android manifest: {error}").into())
 }
 
 #[cfg(test)]
@@ -109,43 +72,20 @@ mod tests {
             }
         }))
         .unwrap()
-        .build_variables
+        .build_variables()
+        .clone()
     }
 
     #[test]
-    fn transforms_xml_values_safely_without_touching_android_placeholders() {
-        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
-            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-                package="com.example.${applicationId}">
-                <application android:label="{{crossbow.LABEL}}" />
-            </manifest>"#;
-        let xml = transform_typed_xml_variables(xml.as_slice(), &variables()).unwrap();
-        let manifest = android_manifest::from_reader(xml.as_slice()).unwrap();
-        let manifest = interpolate_android_manifest(manifest, &variables()).unwrap();
-        assert_eq!(
-            manifest.application.label.unwrap().to_string(),
-            "R&D <Preview> ✓"
-        );
-        assert_eq!(
-            manifest.package.as_deref(),
-            Some("com.example.${applicationId}")
-        );
-    }
-
-    #[test]
-    fn resolves_typed_attributes_before_xml_deserialization() {
+    fn interpolates_strings_and_typed_attributes_without_platform_collisions() {
         let xml = br#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-            package="dev.crossbow.example" android:versionCode="{{crossbow.CODE}}"
+            package="dev.${applicationId}" android:versionCode="{{crossbow.CODE}}"
             android:installLocation="{{crossbow.LOCATION}}">
             <application android:label="{{crossbow.LABEL}}" />
         </manifest>"#;
-        let transformed = transform_typed_xml_variables(xml.as_slice(), &variables()).unwrap();
-        let transformed = String::from_utf8(transformed).unwrap();
-        assert!(transformed.contains("android:versionCode=\"42\""));
-        assert!(transformed.contains("android:installLocation=\"auto\""));
-        assert!(transformed.contains("{{crossbow.LABEL}}"));
-        let manifest = android_manifest::from_reader(transformed.as_bytes()).unwrap();
-        let manifest = interpolate_android_manifest(manifest, &variables()).unwrap();
+        let xml = interpolate_xml(xml.as_slice(), &variables()).unwrap();
+        let manifest = android_manifest::from_reader(xml.as_slice()).unwrap();
+        assert_eq!(manifest.package.as_deref(), Some("dev.${applicationId}"));
         assert_eq!(manifest.version_code, Some(42));
         assert_eq!(
             manifest.install_location,
@@ -158,28 +98,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_undeclared_manifest_placeholders() {
+    fn rejects_undeclared_placeholders() {
         let xml = br#"<manifest package="{{crossbow.NOT_DECLARED}}"><application /></manifest>"#;
-        let error = transform_typed_xml_variables(xml.as_slice(), &BuildVariables::default())
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not declared"));
-
-        let manifest = android_manifest::from_reader(xml.as_slice()).unwrap();
-        let error = interpolate_android_manifest(manifest, &BuildVariables::default())
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not declared"));
+        assert!(
+            interpolate_xml(xml.as_slice(), &BuildVariables::default())
+                .unwrap_err()
+                .to_string()
+                .contains("not declared")
+        );
     }
 
     #[test]
-    fn manifests_without_build_variables_do_not_require_a_json_round_trip() {
+    fn reads_boolean_wrappers_without_variables() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("AndroidManifest.xml");
         std::fs::write(
             &path,
-            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-                package="dev.crossbow.example">
+            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android">
                 <application android:hasCode="true" />
             </manifest>"#,
         )

--- a/crossbundle/tools/src/commands/android/common/read_manifest.rs
+++ b/crossbundle/tools/src/commands/android/common/read_manifest.rs
@@ -23,6 +23,12 @@ pub fn read_android_manifest_with_variables(
     let reader = BufReader::new(&file);
     let xml = transform_typed_xml_variables(reader, variables)?;
     let manifest = android_manifest::from_reader(xml.as_slice()).map_err(AndroidError::from)?;
+    if !xml
+        .windows("{{crossbow.".len())
+        .any(|window| window == b"{{crossbow.")
+    {
+        return Ok(manifest);
+    }
     interpolate_android_manifest(manifest, variables)
 }
 
@@ -84,6 +90,7 @@ fn interpolate_android_manifest(
     let mut value = serde_json::to_value(manifest)
         .map_err(|error| anyhow::anyhow!("failed to inspect Android manifest: {error}"))?;
     interpolate_json_build_variables(&mut value, variables)?;
+    crate::types::normalize_android_manifest_json(&mut value);
     serde_json::from_value(value)
         .map_err(|error| anyhow::anyhow!("invalid resolved Android manifest: {error}").into())
 }
@@ -163,5 +170,24 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("not declared"));
+    }
+
+    #[test]
+    fn manifests_without_build_variables_do_not_require_a_json_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("AndroidManifest.xml");
+        std::fs::write(
+            &path,
+            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="dev.crossbow.example">
+                <application android:hasCode="true" />
+            </manifest>"#,
+        )
+        .unwrap();
+        let manifest = read_android_manifest(&path).unwrap();
+        assert_eq!(
+            manifest.application.has_code,
+            Some(android_manifest::VarOrBool::Bool(true))
+        );
     }
 }

--- a/crossbundle/tools/src/commands/android/common/read_manifest.rs
+++ b/crossbundle/tools/src/commands/android/common/read_manifest.rs
@@ -1,13 +1,167 @@
-use crate::error::{AndroidError, Result};
+use crate::{
+    error::{AndroidError, Result},
+    types::{BuildVariables, interpolate_json_build_variables, interpolate_typed_build_variables},
+};
 use android_manifest::AndroidManifest;
 use std::{fs::File, io::BufReader, path::Path};
 
-/// Read file and deserializes `AndroidManifest.xml` into
-/// [`AndroidManifest`](android_manifest::AndroidManifest)
+/// Reads and deserializes `AndroidManifest.xml`.
 pub fn read_android_manifest(path: &Path) -> Result<AndroidManifest> {
+    read_android_manifest_with_variables(path, &BuildVariables::default())
+}
+
+/// Reads an Android manifest and expands declared Crossbow build variables in its typed XML
+/// attributes. Resolving after XML parsing lets the manifest serializer safely escape arbitrary
+/// variable values when the generated manifest is written.
+pub fn read_android_manifest_with_variables(
+    path: &Path,
+    variables: &BuildVariables,
+) -> Result<AndroidManifest> {
     let file = File::open(path).map_err(|_| {
         AndroidError::FailedToFindAndroidManifest(path.to_string_lossy().to_string())
     })?;
     let reader = BufReader::new(&file);
-    Ok(android_manifest::from_reader(reader).map_err(AndroidError::from)?)
+    let xml = transform_typed_xml_variables(reader, variables)?;
+    let manifest = android_manifest::from_reader(xml.as_slice()).map_err(AndroidError::from)?;
+    interpolate_android_manifest(manifest, variables)
+}
+
+fn transform_typed_xml_variables(
+    reader: impl std::io::Read,
+    variables: &BuildVariables,
+) -> Result<Vec<u8>> {
+    use xml::{reader::XmlEvent as ReaderEvent, writer::XmlEvent as WriterEvent};
+
+    let mut output = Vec::new();
+    let mut writer = xml::EmitterConfig::new()
+        .perform_indent(false)
+        .create_writer(&mut output);
+    for event in xml::EventReader::new(reader) {
+        let mut event = event.map_err(|error| anyhow::anyhow!("invalid Android XML: {error}"))?;
+        match &mut event {
+            ReaderEvent::StartElement { attributes, .. } => {
+                for attribute in attributes {
+                    attribute.value =
+                        interpolate_typed_build_variables(&attribute.value, variables)?;
+                }
+                writer
+                    .write(
+                        event
+                            .as_writer_event()
+                            .expect("start elements are writable"),
+                    )
+                    .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
+            }
+            ReaderEvent::Characters(value) => {
+                let value = interpolate_typed_build_variables(value, variables)?;
+                writer
+                    .write(WriterEvent::characters(&value))
+                    .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
+            }
+            ReaderEvent::CData(value) => {
+                let value = interpolate_typed_build_variables(value, variables)?;
+                writer
+                    .write(WriterEvent::cdata(&value))
+                    .map_err(|error| anyhow::anyhow!("failed to rewrite Android XML: {error}"))?;
+            }
+            _ => {
+                if let Some(event) = event.as_writer_event() {
+                    writer.write(event).map_err(|error| {
+                        anyhow::anyhow!("failed to rewrite Android XML: {error}")
+                    })?;
+                }
+            }
+        }
+    }
+    drop(writer);
+    Ok(output)
+}
+
+fn interpolate_android_manifest(
+    manifest: AndroidManifest,
+    variables: &BuildVariables,
+) -> Result<AndroidManifest> {
+    let mut value = serde_json::to_value(manifest)
+        .map_err(|error| anyhow::anyhow!("failed to inspect Android manifest: {error}"))?;
+    interpolate_json_build_variables(&mut value, variables)?;
+    serde_json::from_value(value)
+        .map_err(|error| anyhow::anyhow!("invalid resolved Android manifest: {error}").into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::deserialize_crossbow_metadata;
+
+    fn variables() -> BuildVariables {
+        deserialize_crossbow_metadata(serde_json::json!({
+            "build_variables": {
+                "LABEL": { "env": "IGNORED_LABEL", "default": "R&D <Preview> ✓" },
+                "CODE": { "env": "IGNORED_CODE", "type": "integer", "default": 42 },
+                "LOCATION": { "env": "IGNORED_LOCATION", "default": "auto" }
+            }
+        }))
+        .unwrap()
+        .build_variables
+    }
+
+    #[test]
+    fn transforms_xml_values_safely_without_touching_android_placeholders() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="com.example.${applicationId}">
+                <application android:label="{{crossbow.LABEL}}" />
+            </manifest>"#;
+        let xml = transform_typed_xml_variables(xml.as_slice(), &variables()).unwrap();
+        let manifest = android_manifest::from_reader(xml.as_slice()).unwrap();
+        let manifest = interpolate_android_manifest(manifest, &variables()).unwrap();
+        assert_eq!(
+            manifest.application.label.unwrap().to_string(),
+            "R&D <Preview> ✓"
+        );
+        assert_eq!(
+            manifest.package.as_deref(),
+            Some("com.example.${applicationId}")
+        );
+    }
+
+    #[test]
+    fn resolves_typed_attributes_before_xml_deserialization() {
+        let xml = br#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+            package="dev.crossbow.example" android:versionCode="{{crossbow.CODE}}"
+            android:installLocation="{{crossbow.LOCATION}}">
+            <application android:label="{{crossbow.LABEL}}" />
+        </manifest>"#;
+        let transformed = transform_typed_xml_variables(xml.as_slice(), &variables()).unwrap();
+        let transformed = String::from_utf8(transformed).unwrap();
+        assert!(transformed.contains("android:versionCode=\"42\""));
+        assert!(transformed.contains("android:installLocation=\"auto\""));
+        assert!(transformed.contains("{{crossbow.LABEL}}"));
+        let manifest = android_manifest::from_reader(transformed.as_bytes()).unwrap();
+        let manifest = interpolate_android_manifest(manifest, &variables()).unwrap();
+        assert_eq!(manifest.version_code, Some(42));
+        assert_eq!(
+            manifest.install_location,
+            Some(android_manifest::InstallLocation::Auto)
+        );
+        assert_eq!(
+            manifest.application.label.unwrap().to_string(),
+            "R&D <Preview> ✓"
+        );
+    }
+
+    #[test]
+    fn rejects_undeclared_manifest_placeholders() {
+        let xml = br#"<manifest package="{{crossbow.NOT_DECLARED}}"><application /></manifest>"#;
+        let error = transform_typed_xml_variables(xml.as_slice(), &BuildVariables::default())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not declared"));
+
+        let manifest = android_manifest::from_reader(xml.as_slice()).unwrap();
+        let error = interpolate_android_manifest(manifest, &BuildVariables::default())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not declared"));
+    }
 }

--- a/crossbundle/tools/src/commands/android/common/save_manifest.rs
+++ b/crossbundle/tools/src/commands/android/common/save_manifest.rs
@@ -1,56 +1,24 @@
-use crate::{
-    error::{AndroidError, Result},
-    types::{BuildVariableValue, BuildVariables},
-};
+use crate::error::{AndroidError, Result};
 use android_manifest::AndroidManifest;
-use std::fs::create_dir_all;
 use std::{
-    fs::File,
+    fs::{File, create_dir_all},
     io::Write,
     path::{Path, PathBuf},
 };
 
-/// Saves given manifest in new `AndroidManifest.xml` file
+/// Saves a manifest as `AndroidManifest.xml`.
 pub fn save_android_manifest(out_dir: &Path, manifest: &AndroidManifest) -> Result<PathBuf> {
-    save_android_manifest_with_variables(out_dir, manifest, &BuildVariables::default())
-}
-
-/// Saves a manifest while preserving arbitrary characters imported through build variables.
-/// `android-manifest` escapes string-like attribute wrappers before the XML writer escapes the
-/// complete attribute; this format-aware pass removes that extra layer only for declared values.
-pub fn save_android_manifest_with_variables(
-    out_dir: &Path,
-    manifest: &AndroidManifest,
-    variables: &BuildVariables,
-) -> Result<PathBuf> {
-    if !out_dir.exists() {
-        create_dir_all(out_dir)?;
-    }
+    create_dir_all(out_dir)?;
     let manifest_path = out_dir.join("AndroidManifest.xml");
-    let mut file = File::create(&manifest_path)?;
-    let given_xml = android_manifest::to_string_pretty(manifest).map_err(AndroidError::from)?;
-    let given_xml = normalize_variable_escaping(&given_xml, variables)?;
-    file.write_all(&given_xml)?;
+    let xml = android_manifest::to_string_pretty(manifest).map_err(AndroidError::from)?;
+    File::create(&manifest_path)?.write_all(&normalize_xml(&xml)?)?;
     Ok(manifest_path)
 }
 
-fn normalize_variable_escaping(xml: &str, variables: &BuildVariables) -> Result<Vec<u8>> {
-    use xml::reader::XmlEvent as ReaderEvent;
-
-    let mut replacements = variables
-        .iter()
-        .filter_map(|(_, value)| match value {
-            BuildVariableValue::String(value) => {
-                let escaped = xml::escape::escape_str_attribute(value).into_owned();
-                (escaped != *value).then_some((escaped, value.as_str()))
-            }
-            BuildVariableValue::Integer(_) | BuildVariableValue::Boolean(_) => None,
-        })
-        .collect::<Vec<_>>();
-    replacements.sort_by_key(|replacement| std::cmp::Reverse(replacement.0.len()));
-    if replacements.is_empty() {
-        return Ok(xml.as_bytes().to_vec());
-    }
+// `android-manifest` serializes wrapped strings through a nested XML writer. Decode that writer's
+// entity layer, then let the final writer apply the one layer required by the document.
+fn normalize_xml(xml: &str) -> Result<Vec<u8>> {
+    use xml::reader::XmlEvent;
 
     let mut output = Vec::new();
     let mut writer = xml::EmitterConfig::new()
@@ -59,17 +27,13 @@ fn normalize_variable_escaping(xml: &str, variables: &BuildVariables) -> Result<
     for event in xml::EventReader::new(xml.as_bytes()) {
         let mut event = event.map_err(|error| anyhow::anyhow!("invalid generated XML: {error}"))?;
         match &mut event {
-            ReaderEvent::StartElement { attributes, .. } => {
+            XmlEvent::StartElement { attributes, .. } => {
                 for attribute in attributes {
-                    for (escaped, raw) in &replacements {
-                        attribute.value = attribute.value.replace(escaped, raw);
-                    }
+                    attribute.value = decode_nested_entities(&attribute.value);
                 }
             }
-            ReaderEvent::Characters(value) | ReaderEvent::CData(value) => {
-                for (escaped, raw) in &replacements {
-                    *value = value.replace(escaped, raw);
-                }
+            XmlEvent::Characters(value) | XmlEvent::CData(value) => {
+                *value = decode_nested_entities(value);
             }
             _ => {}
         }
@@ -83,32 +47,42 @@ fn normalize_variable_escaping(xml: &str, variables: &BuildVariables) -> Result<
     Ok(output)
 }
 
+fn decode_nested_entities(value: &str) -> String {
+    [
+        ("&lt;", "<"),
+        ("&gt;", ">"),
+        ("&quot;", "\""),
+        ("&apos;", "'"),
+        ("&#xA;", "\n"),
+        ("&#xD;", "\r"),
+        ("&amp;", "&"),
+    ]
+    .into_iter()
+    .fold(value.to_owned(), |value, (entity, character)| {
+        value.replace(entity, character)
+    })
+}
+
 #[cfg(test)]
-mod build_variable_tests {
+mod tests {
     use super::*;
     use crate::types::deserialize_crossbow_metadata;
 
     #[test]
-    fn writes_special_characters_with_one_correct_xml_escape_layer() {
+    fn writes_special_characters_with_one_escape_layer() {
         let metadata = deserialize_crossbow_metadata(serde_json::json!({
             "build_variables": {
                 "LABEL": { "env": "IGNORED_LABEL", "default": "R&D <Preview> ✓" }
             },
-            "android": {
-                "manifest": {
-                    "package": "dev.crossbow.example",
-                    "application": { "label": "{{crossbow.LABEL}}" }
-                }
-            }
+            "android": { "manifest": {
+                "package": "dev.crossbow.example",
+                "application": { "label": "{{crossbow.LABEL}}" }
+            }}
         }))
         .unwrap();
         let dir = tempfile::tempdir().unwrap();
-        let path = save_android_manifest_with_variables(
-            dir.path(),
-            metadata.android.manifest.as_ref().unwrap(),
-            &metadata.build_variables,
-        )
-        .unwrap();
+        let path =
+            save_android_manifest(dir.path(), metadata.android.manifest.as_ref().unwrap()).unwrap();
         let xml = std::fs::read_to_string(path).unwrap();
         assert!(xml.contains("R&amp;D &lt;Preview&gt; ✓"), "{xml}");
         assert!(!xml.contains("&amp;amp;"), "{xml}");

--- a/crossbundle/tools/src/commands/android/common/save_manifest.rs
+++ b/crossbundle/tools/src/commands/android/common/save_manifest.rs
@@ -1,4 +1,7 @@
-use crate::error::{AndroidError, Result};
+use crate::{
+    error::{AndroidError, Result},
+    types::{BuildVariableValue, BuildVariables},
+};
 use android_manifest::AndroidManifest;
 use std::fs::create_dir_all;
 use std::{
@@ -9,12 +12,109 @@ use std::{
 
 /// Saves given manifest in new `AndroidManifest.xml` file
 pub fn save_android_manifest(out_dir: &Path, manifest: &AndroidManifest) -> Result<PathBuf> {
+    save_android_manifest_with_variables(out_dir, manifest, &BuildVariables::default())
+}
+
+/// Saves a manifest while preserving arbitrary characters imported through build variables.
+/// `android-manifest` escapes string-like attribute wrappers before the XML writer escapes the
+/// complete attribute; this format-aware pass removes that extra layer only for declared values.
+pub fn save_android_manifest_with_variables(
+    out_dir: &Path,
+    manifest: &AndroidManifest,
+    variables: &BuildVariables,
+) -> Result<PathBuf> {
     if !out_dir.exists() {
         create_dir_all(out_dir)?;
     }
     let manifest_path = out_dir.join("AndroidManifest.xml");
     let mut file = File::create(&manifest_path)?;
     let given_xml = android_manifest::to_string_pretty(manifest).map_err(AndroidError::from)?;
-    file.write_all(given_xml.as_bytes())?;
+    let given_xml = normalize_variable_escaping(&given_xml, variables)?;
+    file.write_all(&given_xml)?;
     Ok(manifest_path)
+}
+
+fn normalize_variable_escaping(xml: &str, variables: &BuildVariables) -> Result<Vec<u8>> {
+    use xml::reader::XmlEvent as ReaderEvent;
+
+    let mut replacements = variables
+        .iter()
+        .filter_map(|(_, value)| match value {
+            BuildVariableValue::String(value) => {
+                let escaped = xml::escape::escape_str_attribute(value).into_owned();
+                (escaped != *value).then_some((escaped, value.as_str()))
+            }
+            BuildVariableValue::Integer(_) | BuildVariableValue::Boolean(_) => None,
+        })
+        .collect::<Vec<_>>();
+    replacements.sort_by_key(|replacement| std::cmp::Reverse(replacement.0.len()));
+    if replacements.is_empty() {
+        return Ok(xml.as_bytes().to_vec());
+    }
+
+    let mut output = Vec::new();
+    let mut writer = xml::EmitterConfig::new()
+        .perform_indent(true)
+        .create_writer(&mut output);
+    for event in xml::EventReader::new(xml.as_bytes()) {
+        let mut event = event.map_err(|error| anyhow::anyhow!("invalid generated XML: {error}"))?;
+        match &mut event {
+            ReaderEvent::StartElement { attributes, .. } => {
+                for attribute in attributes {
+                    for (escaped, raw) in &replacements {
+                        attribute.value = attribute.value.replace(escaped, raw);
+                    }
+                }
+            }
+            ReaderEvent::Characters(value) | ReaderEvent::CData(value) => {
+                for (escaped, raw) in &replacements {
+                    *value = value.replace(escaped, raw);
+                }
+            }
+            _ => {}
+        }
+        if let Some(event) = event.as_writer_event() {
+            writer
+                .write(event)
+                .map_err(|error| anyhow::anyhow!("failed to write generated XML: {error}"))?;
+        }
+    }
+    drop(writer);
+    Ok(output)
+}
+
+#[cfg(test)]
+mod build_variable_tests {
+    use super::*;
+    use crate::types::deserialize_crossbow_metadata;
+
+    #[test]
+    fn writes_special_characters_with_one_correct_xml_escape_layer() {
+        let metadata = deserialize_crossbow_metadata(serde_json::json!({
+            "build_variables": {
+                "LABEL": { "env": "IGNORED_LABEL", "default": "R&D <Preview> ✓" }
+            },
+            "android": {
+                "manifest": {
+                    "package": "dev.crossbow.example",
+                    "application": { "label": "{{crossbow.LABEL}}" }
+                }
+            }
+        }))
+        .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = save_android_manifest_with_variables(
+            dir.path(),
+            metadata.android.manifest.as_ref().unwrap(),
+            &metadata.build_variables,
+        )
+        .unwrap();
+        let xml = std::fs::read_to_string(path).unwrap();
+        assert!(xml.contains("R&amp;D &lt;Preview&gt; ✓"), "{xml}");
+        assert!(!xml.contains("&amp;amp;"), "{xml}");
+        xml::EventReader::new(xml.as_bytes())
+            .into_iter()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+    }
 }

--- a/crossbundle/tools/src/commands/apple/read_plist.rs
+++ b/crossbundle/tools/src/commands/apple/read_plist.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::{AppleError, Result},
     types::{
-        BuildVariableValue, BuildVariables, CrossbowMetadata, exact_build_variable,
-        interpolate_build_variables, update_info_plist_with_default,
+        BuildVariables, CrossbowMetadata, exact_variable, interpolate_string,
+        update_info_plist_with_default,
     },
 };
 use apple_bundle::{plist, prelude::InfoPlist};
@@ -16,10 +16,7 @@ pub fn read_info_plist(path: &Path) -> Result<InfoPlist> {
 
 /// Reads an XML or binary Info.plist after recursively expanding declared Crossbow build
 /// variables.
-pub fn read_info_plist_with_variables(
-    path: &Path,
-    variables: &BuildVariables,
-) -> Result<InfoPlist> {
+fn read_info_plist_with_variables(path: &Path, variables: &BuildVariables) -> Result<InfoPlist> {
     if !path.exists() {
         return Err(AppleError::FailedToFindInfoPlist(path.to_string_lossy().to_string()).into());
     }
@@ -41,14 +38,10 @@ fn interpolate_plist(value: &mut plist::Value, variables: &BuildVariables) -> Re
             }
         }
         plist::Value::String(template) => {
-            if let Some(resolved) = exact_build_variable(template, variables)? {
-                *value = match resolved {
-                    BuildVariableValue::String(value) => plist::Value::String(value.clone()),
-                    BuildVariableValue::Integer(value) => plist::Value::Integer((*value).into()),
-                    BuildVariableValue::Boolean(value) => plist::Value::Boolean(*value),
-                };
+            if let Some(resolved) = exact_variable(template, variables)? {
+                *value = plist::to_value(resolved)?;
             } else {
-                *template = interpolate_build_variables(template, variables)?;
+                *template = interpolate_string(template, variables)?;
             }
         }
         _ => {}
@@ -63,7 +56,7 @@ pub fn resolve_info_plist(
     configured_path: Option<&Path>,
 ) -> Result<InfoPlist> {
     if let Some(path) = configured_path {
-        return read_info_plist_with_variables(path, &metadata.build_variables);
+        return read_info_plist_with_variables(path, metadata.build_variables());
     }
     let mut plist = metadata.apple.info_plist.clone().unwrap_or_default();
     update_info_plist_with_default(&mut plist, package_name, metadata.app_name.clone());
@@ -108,7 +101,7 @@ mod tests {
                 plist::Value::String("build-{{crossbow.BUILD}}".into()),
             )])),
         ]);
-        interpolate_plist(&mut value, &metadata.build_variables).unwrap();
+        interpolate_plist(&mut value, metadata.build_variables()).unwrap();
         assert_eq!(
             value,
             plist::Value::Array(vec![
@@ -146,7 +139,7 @@ mod tests {
             } else {
                 value.to_file_xml(&path).unwrap();
             }
-            let plist = read_info_plist_with_variables(&path, &metadata.build_variables).unwrap();
+            let plist = read_info_plist_with_variables(&path, metadata.build_variables()).unwrap();
             assert_eq!(plist.naming.bundle_name.as_deref(), Some("Crossbow ✓"));
             assert_eq!(plist.styling.requires_full_screen, Some(true));
         }

--- a/crossbundle/tools/src/commands/apple/read_plist.rs
+++ b/crossbundle/tools/src/commands/apple/read_plist.rs
@@ -1,18 +1,59 @@
 use crate::{
     error::{AppleError, Result},
-    types::{CrossbowMetadata, update_info_plist_with_default},
+    types::{
+        BuildVariableValue, BuildVariables, CrossbowMetadata, exact_build_variable,
+        interpolate_build_variables, update_info_plist_with_default,
+    },
 };
-use apple_bundle::prelude::InfoPlist;
+use apple_bundle::{plist, prelude::InfoPlist};
 use std::path::Path;
 
 /// Read file and deserializes `Info.plist` into
 /// [`InfoPlist`](apple_bundle::prelude::InfoPlist).
 pub fn read_info_plist(path: &Path) -> Result<InfoPlist> {
+    read_info_plist_with_variables(path, &BuildVariables::default())
+}
+
+/// Reads an XML or binary Info.plist after recursively expanding declared Crossbow build
+/// variables.
+pub fn read_info_plist_with_variables(
+    path: &Path,
+    variables: &BuildVariables,
+) -> Result<InfoPlist> {
     if !path.exists() {
         return Err(AppleError::FailedToFindInfoPlist(path.to_string_lossy().to_string()).into());
     }
-    let res = apple_bundle::from_file(path)?;
-    Ok(res)
+    let mut value = plist::Value::from_file(path)?;
+    interpolate_plist(&mut value, variables)?;
+    Ok(plist::from_value(&value)?)
+}
+
+fn interpolate_plist(value: &mut plist::Value, variables: &BuildVariables) -> Result<()> {
+    match value {
+        plist::Value::Array(values) => {
+            for value in values {
+                interpolate_plist(value, variables)?;
+            }
+        }
+        plist::Value::Dictionary(values) => {
+            for value in values.values_mut() {
+                interpolate_plist(value, variables)?;
+            }
+        }
+        plist::Value::String(template) => {
+            if let Some(resolved) = exact_build_variable(template, variables)? {
+                *value = match resolved {
+                    BuildVariableValue::String(value) => plist::Value::String(value.clone()),
+                    BuildVariableValue::Integer(value) => plist::Value::Integer((*value).into()),
+                    BuildVariableValue::Boolean(value) => plist::Value::Boolean(*value),
+                };
+            } else {
+                *template = interpolate_build_variables(template, variables)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Resolves the same typed Info.plist used by Apple builds without writing it.
@@ -22,7 +63,7 @@ pub fn resolve_info_plist(
     configured_path: Option<&Path>,
 ) -> Result<InfoPlist> {
     if let Some(path) = configured_path {
-        return read_info_plist(path);
+        return read_info_plist_with_variables(path, &metadata.build_variables);
     }
     let mut plist = metadata.apple.info_plist.clone().unwrap_or_default();
     update_info_plist_with_default(&mut plist, package_name, metadata.app_name.clone());
@@ -37,6 +78,17 @@ mod tests {
     use super::*;
     use crossbow::Permission;
 
+    fn metadata_with_variables() -> CrossbowMetadata {
+        crate::types::deserialize_crossbow_metadata(serde_json::json!({
+            "build_variables": {
+                "NAME": { "env": "IGNORED_NAME", "default": "Crossbow ✓" },
+                "FULLSCREEN": { "env": "IGNORED_FULLSCREEN", "type": "boolean", "default": true },
+                "BUILD": { "env": "IGNORED_BUILD", "type": "integer", "default": 42 }
+            }
+        }))
+        .unwrap()
+    }
+
     #[test]
     fn resolution_applies_typed_permissions() {
         let mut metadata = CrossbowMetadata::default();
@@ -44,5 +96,59 @@ mod tests {
         let plist = resolve_info_plist(&metadata, "example", None).unwrap();
         let description = plist.camera_and_microphone.camera_usage_description;
         assert!(description.is_some());
+    }
+
+    #[test]
+    fn recursively_interpolates_typed_plist_values() {
+        let metadata = metadata_with_variables();
+        let mut value = plist::Value::Array(vec![
+            plist::Value::String("{{crossbow.FULLSCREEN}}".into()),
+            plist::Value::Dictionary(plist::Dictionary::from_iter([(
+                "nested".to_owned(),
+                plist::Value::String("build-{{crossbow.BUILD}}".into()),
+            )])),
+        ]);
+        interpolate_plist(&mut value, &metadata.build_variables).unwrap();
+        assert_eq!(
+            value,
+            plist::Value::Array(vec![
+                plist::Value::Boolean(true),
+                plist::Value::Dictionary(plist::Dictionary::from_iter([(
+                    "nested".to_owned(),
+                    plist::Value::String("build-42".into()),
+                )])),
+            ])
+        );
+    }
+
+    #[test]
+    fn reads_variables_from_xml_and_binary_plists() {
+        let metadata = metadata_with_variables();
+        for binary in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("Info.plist");
+            let value = plist::Value::Dictionary(plist::Dictionary::from_iter([
+                (
+                    "CFBundleIdentifier".to_owned(),
+                    plist::Value::String("dev.crossbow.example".into()),
+                ),
+                (
+                    "CFBundleName".to_owned(),
+                    plist::Value::String("{{crossbow.NAME}}".into()),
+                ),
+                (
+                    "UIRequiresFullScreen".to_owned(),
+                    plist::Value::String("{{crossbow.FULLSCREEN}}".into()),
+                ),
+            ]));
+            if binary {
+                value.to_file_binary(&path).unwrap();
+            } else {
+                value.to_file_xml(&path).unwrap();
+            }
+            let plist = read_info_plist_with_variables(&path, &metadata.build_variables).unwrap();
+            assert_eq!(plist.naming.bundle_name.as_deref(), Some("Crossbow ✓"));
+            assert_eq!(plist.styling.requires_full_screen, Some(true));
+        }
     }
 }

--- a/crossbundle/tools/src/types/android/manifest.rs
+++ b/crossbundle/tools/src/types/android/manifest.rs
@@ -6,10 +6,9 @@ use android_manifest::*;
 pub const DEFAULT_ANDROID_MIN_SDK: u32 = 23;
 pub const DEFAULT_ANDROID_TARGET_SDK: u32 = 36;
 
-/// Adapts `android-manifest`'s JSON representation for its own deserializer. Its `VarOrBool`
-/// serializer emits JSON booleans while its deserializer currently requests strings; the one
-/// native Boolean field must remain a Boolean.
-pub fn normalize_android_manifest_json(value: &mut serde_json::Value) {
+/// Adapts inline metadata to `android-manifest`'s `VarOrBool` deserializer. It requests strings
+/// even though Boolean values are otherwise native; `auto_verify` is the one native Boolean field.
+pub(crate) fn normalize_android_booleans(value: &mut serde_json::Value) {
     fn normalize(value: &mut serde_json::Value, field: Option<&str>) {
         match value {
             serde_json::Value::Bool(boolean) if field != Some("auto_verify") => {
@@ -227,24 +226,5 @@ mod tests {
             Some("android.app.NativeActivity")
         );
         assert_eq!(manifest.application.activity[0].meta_data.len(), 1);
-    }
-
-    #[test]
-    fn json_round_trip_handles_manifest_boolean_wrappers() {
-        let manifest = android_manifest::from_str(
-            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-                package="dev.crossbow.example">
-                <application android:hasCode="true">
-                    <activity android:name=".MainActivity" android:exported="true">
-                        <intent-filter android:autoVerify="true" />
-                    </activity>
-                </application>
-            </manifest>"#,
-        )
-        .unwrap();
-        let mut value = serde_json::to_value(&manifest).unwrap();
-        normalize_android_manifest_json(&mut value);
-        let round_trip: AndroidManifest = serde_json::from_value(value).unwrap();
-        assert_eq!(round_trip, manifest);
     }
 }

--- a/crossbundle/tools/src/types/android/manifest.rs
+++ b/crossbundle/tools/src/types/android/manifest.rs
@@ -6,6 +6,31 @@ use android_manifest::*;
 pub const DEFAULT_ANDROID_MIN_SDK: u32 = 23;
 pub const DEFAULT_ANDROID_TARGET_SDK: u32 = 36;
 
+/// Adapts `android-manifest`'s JSON representation for its own deserializer. Its `VarOrBool`
+/// serializer emits JSON booleans while its deserializer currently requests strings; the one
+/// native Boolean field must remain a Boolean.
+pub fn normalize_android_manifest_json(value: &mut serde_json::Value) {
+    fn normalize(value: &mut serde_json::Value, field: Option<&str>) {
+        match value {
+            serde_json::Value::Bool(boolean) if field != Some("auto_verify") => {
+                *value = serde_json::Value::String(boolean.to_string());
+            }
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    normalize(value, None);
+                }
+            }
+            serde_json::Value::Object(values) => {
+                for (field, value) in values {
+                    normalize(value, Some(field));
+                }
+            }
+            _ => {}
+        }
+    }
+    normalize(value, None);
+}
+
 /// Returns the Activity that handles the manifest's launcher intent.
 pub fn launcher_activity(manifest: &AndroidManifest) -> Option<&str> {
     manifest
@@ -202,5 +227,24 @@ mod tests {
             Some("android.app.NativeActivity")
         );
         assert_eq!(manifest.application.activity[0].meta_data.len(), 1);
+    }
+
+    #[test]
+    fn json_round_trip_handles_manifest_boolean_wrappers() {
+        let manifest = android_manifest::from_str(
+            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="dev.crossbow.example">
+                <application android:hasCode="true">
+                    <activity android:name=".MainActivity" android:exported="true">
+                        <intent-filter android:autoVerify="true" />
+                    </activity>
+                </application>
+            </manifest>"#,
+        )
+        .unwrap();
+        let mut value = serde_json::to_value(&manifest).unwrap();
+        normalize_android_manifest_json(&mut value);
+        let round_trip: AndroidManifest = serde_json::from_value(value).unwrap();
+        assert_eq!(round_trip, manifest);
     }
 }

--- a/crossbundle/tools/src/types/common/build_variables.rs
+++ b/crossbundle/tools/src/types/common/build_variables.rs
@@ -1,0 +1,405 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+const PLACEHOLDER_PREFIX: &str = "{{crossbow.";
+
+/// Values explicitly imported from the build environment.
+///
+/// Only variables declared in `package.metadata.build_variables` are present. Values are
+/// configuration embedded in the application bundle and must not be treated as secrets.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BuildVariables(BTreeMap<String, BuildVariableValue>);
+
+impl BuildVariables {
+    pub fn get(&self, name: &str) -> Option<&BuildVariableValue> {
+        self.0.get(name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &BuildVariableValue)> {
+        self.0.iter().map(|(name, value)| (name.as_str(), value))
+    }
+}
+
+/// A resolved build variable, retaining its declared type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum BuildVariableValue {
+    String(String),
+    Integer(i64),
+    Boolean(bool),
+}
+
+impl BuildVariableValue {
+    pub fn as_string(&self) -> String {
+        match self {
+            Self::String(value) => value.clone(),
+            Self::Integer(value) => value.to_string(),
+            Self::Boolean(value) => value.to_string(),
+        }
+    }
+
+    fn as_json(&self) -> serde_json::Value {
+        match self {
+            Self::String(value) => serde_json::Value::String(value.clone()),
+            Self::Integer(value) => serde_json::Value::Number((*value).into()),
+            Self::Boolean(value) => serde_json::Value::Bool(*value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum BuildVariableType {
+    #[default]
+    String,
+    Integer,
+    Boolean,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BuildVariableDefinition {
+    env: String,
+    #[serde(rename = "type", default)]
+    value_type: BuildVariableType,
+    default: Option<serde_json::Value>,
+}
+
+type BuildVariableDefinitions = BTreeMap<String, BuildVariableDefinition>;
+
+/// Resolves declared variables and expands placeholders throughout package metadata before it is
+/// deserialized into the platform-specific models.
+pub(crate) fn resolve_metadata_build_variables(
+    metadata: &mut serde_json::Value,
+) -> anyhow::Result<BuildVariables> {
+    let definitions = take_definitions(metadata)?;
+    let variables = resolve_definitions(&definitions, |name| match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("environment variable `{name}` is not valid Unicode")
+        }
+    })?;
+    interpolate_json_build_variables(metadata, &variables)?;
+    Ok(variables)
+}
+
+fn take_definitions(metadata: &mut serde_json::Value) -> anyhow::Result<BuildVariableDefinitions> {
+    let Some(table) = metadata.as_object_mut() else {
+        return Ok(BuildVariableDefinitions::new());
+    };
+    let Some(raw) = table.remove("build_variables") else {
+        return Ok(BuildVariableDefinitions::new());
+    };
+    serde_json::from_value(raw)
+        .map_err(|error| anyhow::anyhow!("invalid `package.metadata.build_variables`: {error}"))
+}
+
+fn resolve_definitions<F>(
+    definitions: &BuildVariableDefinitions,
+    mut environment: F,
+) -> anyhow::Result<BuildVariables>
+where
+    F: FnMut(&str) -> anyhow::Result<Option<String>>,
+{
+    let mut values = BTreeMap::new();
+    for (name, definition) in definitions {
+        validate_variable_name(name)?;
+        if definition.env.is_empty() {
+            anyhow::bail!("build variable `{name}` has an empty environment variable name");
+        }
+        let value = match environment(&definition.env)? {
+            Some(value) => parse_environment_value(name, value, definition.value_type)?,
+            None => match &definition.default {
+                Some(default) => parse_default_value(name, default, definition.value_type)?,
+                None => anyhow::bail!(
+                    "build variable `{name}` requires environment variable `{}` or a default",
+                    definition.env
+                ),
+            },
+        };
+        values.insert(name.clone(), value);
+    }
+    Ok(BuildVariables(values))
+}
+
+fn validate_variable_name(name: &str) -> anyhow::Result<()> {
+    let mut chars = name.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric());
+    if !valid {
+        anyhow::bail!(
+            "invalid build variable name `{name}`; use ASCII letters, digits, and underscores, starting with a letter or underscore"
+        );
+    }
+    Ok(())
+}
+
+fn parse_environment_value(
+    name: &str,
+    value: String,
+    value_type: BuildVariableType,
+) -> anyhow::Result<BuildVariableValue> {
+    match value_type {
+        BuildVariableType::String => Ok(BuildVariableValue::String(value)),
+        BuildVariableType::Integer => value
+            .parse()
+            .map(BuildVariableValue::Integer)
+            .map_err(|_| anyhow::anyhow!("build variable `{name}` must be an integer")),
+        BuildVariableType::Boolean => value
+            .parse()
+            .map(BuildVariableValue::Boolean)
+            .map_err(|_| anyhow::anyhow!("build variable `{name}` must be `true` or `false`")),
+    }
+}
+
+fn parse_default_value(
+    name: &str,
+    value: &serde_json::Value,
+    value_type: BuildVariableType,
+) -> anyhow::Result<BuildVariableValue> {
+    let resolved = match value_type {
+        BuildVariableType::String => value
+            .as_str()
+            .map(|value| BuildVariableValue::String(value.to_owned())),
+        BuildVariableType::Integer => value.as_i64().map(BuildVariableValue::Integer),
+        BuildVariableType::Boolean => value.as_bool().map(BuildVariableValue::Boolean),
+    };
+    resolved.ok_or_else(|| {
+        anyhow::anyhow!(
+            "default for build variable `{name}` does not match its declared {} type",
+            match value_type {
+                BuildVariableType::String => "string",
+                BuildVariableType::Integer => "integer",
+                BuildVariableType::Boolean => "boolean",
+            }
+        )
+    })
+}
+
+/// Recursively expands Crossbow placeholders in JSON-like typed configuration data. An exact
+/// placeholder retains its declared integer or Boolean type.
+pub fn interpolate_json_build_variables(
+    value: &mut serde_json::Value,
+    variables: &BuildVariables,
+) -> anyhow::Result<()> {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                interpolate_json_build_variables(value, variables)?;
+            }
+        }
+        serde_json::Value::Object(values) => {
+            for value in values.values_mut() {
+                interpolate_json_build_variables(value, variables)?;
+            }
+        }
+        serde_json::Value::String(template) => {
+            if let Some(resolved) = exact_build_variable(template, variables)? {
+                *value = resolved.as_json();
+            } else {
+                *template = interpolate_string(template, variables)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn exact_placeholder(template: &str) -> Option<&str> {
+    template
+        .strip_prefix(PLACEHOLDER_PREFIX)?
+        .strip_suffix("}}")
+        .filter(|name| !name.contains("}}"))
+}
+
+/// Returns the typed value when the entire string is one Crossbow placeholder.
+pub fn exact_build_variable<'a>(
+    template: &str,
+    variables: &'a BuildVariables,
+) -> anyhow::Result<Option<&'a BuildVariableValue>> {
+    let Some(name) = exact_placeholder(template) else {
+        return Ok(None);
+    };
+    validate_variable_name(name)?;
+    variable(variables, name).map(Some)
+}
+
+/// Expands all Crossbow placeholders in a string while leaving Android `${...}` and Xcode
+/// `$(...)` build-setting syntax untouched.
+pub fn interpolate_build_variables(
+    template: &str,
+    variables: &BuildVariables,
+) -> anyhow::Result<String> {
+    interpolate_string(template, variables)
+}
+
+/// Expands integer, Boolean, and XML-safe string variables before Android's typed XML parser.
+/// Strings requiring XML entities remain as placeholders until after parsing, avoiding a
+/// double-unescape limitation in the upstream manifest deserializer.
+pub fn interpolate_typed_build_variables(
+    template: &str,
+    variables: &BuildVariables,
+) -> anyhow::Result<String> {
+    interpolate_string_with(template, variables, |placeholder, value| match value {
+        BuildVariableValue::String(value)
+            if xml::escape::escape_str_attribute(value).as_ref() == value =>
+        {
+            value.clone()
+        }
+        BuildVariableValue::String(_) => placeholder.to_owned(),
+        BuildVariableValue::Integer(_) | BuildVariableValue::Boolean(_) => value.as_string(),
+    })
+}
+
+fn interpolate_string(template: &str, variables: &BuildVariables) -> anyhow::Result<String> {
+    interpolate_string_with(template, variables, |_, value| value.as_string())
+}
+
+fn interpolate_string_with(
+    template: &str,
+    variables: &BuildVariables,
+    mut replacement: impl FnMut(&str, &BuildVariableValue) -> String,
+) -> anyhow::Result<String> {
+    let mut output = String::with_capacity(template.len());
+    let mut remaining = template;
+    while let Some(start) = remaining.find(PLACEHOLDER_PREFIX) {
+        output.push_str(&remaining[..start]);
+        let placeholder = &remaining[start + PLACEHOLDER_PREFIX.len()..];
+        let Some(end) = placeholder.find("}}") else {
+            anyhow::bail!("unterminated Crossbow build variable placeholder");
+        };
+        let name = &placeholder[..end];
+        validate_variable_name(name)?;
+        let original = &remaining[start..start + PLACEHOLDER_PREFIX.len() + end + 2];
+        output.push_str(&replacement(original, variable(variables, name)?));
+        remaining = &placeholder[end + 2..];
+    }
+    output.push_str(remaining);
+    Ok(output)
+}
+
+fn variable<'a>(
+    variables: &'a BuildVariables,
+    name: &str,
+) -> anyhow::Result<&'a BuildVariableValue> {
+    variables.get(name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "build variable `{name}` is used but not declared in `package.metadata.build_variables`"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn definitions() -> BuildVariableDefinitions {
+        serde_json::from_value(serde_json::json!({
+            "HOST": { "env": "API_HOST", "default": "localhost" },
+            "BUILD": { "env": "BUILD_NUMBER", "type": "integer", "default": 7 },
+            "ENABLED": { "env": "FEATURE_ENABLED", "type": "boolean", "default": false }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn environment_wins_and_defaults_retain_types() {
+        let values = resolve_definitions(&definitions(), |name| {
+            Ok((name == "API_HOST").then(|| "api.example.com".to_owned()))
+        })
+        .unwrap();
+        assert_eq!(
+            values.get("HOST"),
+            Some(&BuildVariableValue::String("api.example.com".into()))
+        );
+        assert_eq!(values.get("BUILD"), Some(&BuildVariableValue::Integer(7)));
+        assert_eq!(
+            values.get("ENABLED"),
+            Some(&BuildVariableValue::Boolean(false))
+        );
+    }
+
+    #[test]
+    fn expands_embedded_unicode_and_preserves_platform_placeholders() {
+        let values = resolve_definitions(&definitions(), |_| Ok(None)).unwrap();
+        let result = interpolate_string(
+            "https://{{crossbow.HOST}}/build/{{crossbow.BUILD}}/✓/${applicationId}/$(PRODUCT_NAME)",
+            &values,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            "https://localhost/build/7/✓/${applicationId}/$(PRODUCT_NAME)"
+        );
+    }
+
+    #[test]
+    fn exact_json_placeholders_become_typed_values() {
+        let values = resolve_definitions(&definitions(), |_| Ok(None)).unwrap();
+        let mut metadata = serde_json::json!({
+            "number": "{{crossbow.BUILD}}",
+            "enabled": "{{crossbow.ENABLED}}",
+            "label": "build-{{crossbow.BUILD}}"
+        });
+        interpolate_json_build_variables(&mut metadata, &values).unwrap();
+        assert_eq!(metadata["number"], 7);
+        assert_eq!(metadata["enabled"], false);
+        assert_eq!(metadata["label"], "build-7");
+    }
+
+    #[test]
+    fn rejects_missing_invalid_and_undeclared_variables() {
+        let mut missing = definitions();
+        missing.get_mut("HOST").unwrap().default = None;
+        assert!(
+            resolve_definitions(&missing, |_| Ok(None))
+                .unwrap_err()
+                .to_string()
+                .contains("requires environment variable `API_HOST`")
+        );
+        assert!(
+            interpolate_string("{{crossbow.SECRET}}", &BuildVariables::default())
+                .unwrap_err()
+                .to_string()
+                .contains("not declared")
+        );
+        assert!(
+            interpolate_string("{{crossbow.HOST", &BuildVariables::default())
+                .unwrap_err()
+                .to_string()
+                .contains("unterminated")
+        );
+    }
+
+    #[test]
+    fn rejects_environment_and_default_type_mismatches() {
+        let integer: BuildVariableDefinitions = serde_json::from_value(serde_json::json!({
+            "BUILD": { "env": "BUILD_NUMBER", "type": "integer" }
+        }))
+        .unwrap();
+        assert!(
+            resolve_definitions(&integer, |_| Ok(Some("1.5".into())))
+                .unwrap_err()
+                .to_string()
+                .contains("must be an integer")
+        );
+
+        let boolean: BuildVariableDefinitions = serde_json::from_value(serde_json::json!({
+            "ENABLED": { "env": "FEATURE_ENABLED", "type": "boolean", "default": "true" }
+        }))
+        .unwrap();
+        assert!(
+            resolve_definitions(&boolean, |_| Ok(None))
+                .unwrap_err()
+                .to_string()
+                .contains("does not match its declared boolean type")
+        );
+    }
+}

--- a/crossbundle/tools/src/types/common/build_variables.rs
+++ b/crossbundle/tools/src/types/common/build_variables.rs
@@ -1,57 +1,34 @@
-use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use serde::Deserialize;
+use serde_json::Value;
+use std::{borrow::Cow, collections::BTreeMap, fmt};
 
 const PLACEHOLDER_PREFIX: &str = "{{crossbow.";
 
-/// Values explicitly imported from the build environment.
-///
-/// Only variables declared in `package.metadata.build_variables` are present. Values are
-/// configuration embedded in the application bundle and must not be treated as secrets.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct BuildVariables(BTreeMap<String, BuildVariableValue>);
+/// Allow-listed build-environment values used in platform configuration.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct BuildVariables(BTreeMap<String, Value>);
+
+// Resolved values are public application configuration, but still must not leak into diagnostics.
+impl fmt::Debug for BuildVariables {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BuildVariables")
+            .field("names", &self.0.keys())
+            .finish()
+    }
+}
 
 impl BuildVariables {
-    pub fn get(&self, name: &str) -> Option<&BuildVariableValue> {
+    pub(crate) fn get(&self, name: &str) -> Option<&Value> {
         self.0.get(name)
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &BuildVariableValue)> {
-        self.0.iter().map(|(name, value)| (name.as_str(), value))
-    }
 }
 
-/// A resolved build variable, retaining its declared type.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
-pub enum BuildVariableValue {
-    String(String),
-    Integer(i64),
-    Boolean(bool),
-}
-
-impl BuildVariableValue {
-    pub fn as_string(&self) -> String {
-        match self {
-            Self::String(value) => value.clone(),
-            Self::Integer(value) => value.to_string(),
-            Self::Boolean(value) => value.to_string(),
-        }
-    }
-
-    fn as_json(&self) -> serde_json::Value {
-        match self {
-            Self::String(value) => serde_json::Value::String(value.clone()),
-            Self::Integer(value) => serde_json::Value::Number((*value).into()),
-            Self::Boolean(value) => serde_json::Value::Bool(*value),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[derive(Clone, Copy, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum BuildVariableType {
     #[default]
@@ -60,21 +37,51 @@ enum BuildVariableType {
     Boolean,
 }
 
-#[derive(Debug, Deserialize)]
+impl BuildVariableType {
+    fn name(self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Integer => "integer",
+            Self::Boolean => "boolean",
+        }
+    }
+
+    fn accepts(self, value: &Value) -> bool {
+        match self {
+            Self::String => value.is_string(),
+            Self::Integer => value.as_i64().is_some(),
+            Self::Boolean => value.is_boolean(),
+        }
+    }
+
+    fn parse(self, name: &str, value: String) -> anyhow::Result<Value> {
+        match self {
+            Self::String => Ok(Value::String(value)),
+            Self::Integer => value
+                .parse::<i64>()
+                .map(Value::from)
+                .map_err(|_| anyhow::anyhow!("build variable `{name}` must be an integer")),
+            Self::Boolean => value
+                .parse::<bool>()
+                .map(Value::from)
+                .map_err(|_| anyhow::anyhow!("build variable `{name}` must be `true` or `false`")),
+        }
+    }
+}
+
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct BuildVariableDefinition {
     env: String,
     #[serde(rename = "type", default)]
     value_type: BuildVariableType,
-    default: Option<serde_json::Value>,
+    default: Option<Value>,
 }
 
 type BuildVariableDefinitions = BTreeMap<String, BuildVariableDefinition>;
 
-/// Resolves declared variables and expands placeholders throughout package metadata before it is
-/// deserialized into the platform-specific models.
 pub(crate) fn resolve_metadata_build_variables(
-    metadata: &mut serde_json::Value,
+    metadata: &mut Value,
 ) -> anyhow::Result<BuildVariables> {
     let definitions = take_definitions(metadata)?;
     let variables = resolve_definitions(&definitions, |name| match std::env::var(name) {
@@ -84,56 +91,84 @@ pub(crate) fn resolve_metadata_build_variables(
             anyhow::bail!("environment variable `{name}` is not valid Unicode")
         }
     })?;
-    interpolate_json_build_variables(metadata, &variables)?;
+
+    // Limit expansion to the public platform documents named by the feature. In particular,
+    // values must never flow into paths, plugin configuration, or other generated files.
+    for pointer in ["/android/manifest", "/apple/info_plist"] {
+        if let Some(value) = metadata.pointer_mut(pointer) {
+            interpolate_json(value, &variables)?;
+        }
+    }
     Ok(variables)
 }
 
-fn take_definitions(metadata: &mut serde_json::Value) -> anyhow::Result<BuildVariableDefinitions> {
-    let Some(table) = metadata.as_object_mut() else {
-        return Ok(BuildVariableDefinitions::new());
-    };
-    let Some(raw) = table.remove("build_variables") else {
+fn take_definitions(metadata: &mut Value) -> anyhow::Result<BuildVariableDefinitions> {
+    let Some(raw) = metadata
+        .as_object_mut()
+        .and_then(|metadata| metadata.remove("build_variables"))
+    else {
         return Ok(BuildVariableDefinitions::new());
     };
     serde_json::from_value(raw)
         .map_err(|error| anyhow::anyhow!("invalid `package.metadata.build_variables`: {error}"))
 }
 
-fn resolve_definitions<F>(
+fn resolve_definitions(
     definitions: &BuildVariableDefinitions,
-    mut environment: F,
-) -> anyhow::Result<BuildVariables>
-where
-    F: FnMut(&str) -> anyhow::Result<Option<String>>,
-{
+    mut environment: impl FnMut(&str) -> anyhow::Result<Option<String>>,
+) -> anyhow::Result<BuildVariables> {
     let mut values = BTreeMap::new();
     for (name, definition) in definitions {
-        validate_variable_name(name)?;
+        validate_name(name)?;
         if definition.env.is_empty() {
             anyhow::bail!("build variable `{name}` has an empty environment variable name");
         }
-        let value = match environment(&definition.env)? {
-            Some(value) => parse_environment_value(name, value, definition.value_type)?,
-            None => match &definition.default {
-                Some(default) => parse_default_value(name, default, definition.value_type)?,
-                None => anyhow::bail!(
-                    "build variable `{name}` requires environment variable `{}` or a default",
-                    definition.env
-                ),
-            },
+        if definition
+            .default
+            .as_ref()
+            .is_some_and(|value| !definition.value_type.accepts(value))
+        {
+            anyhow::bail!(
+                "default for build variable `{name}` does not match its declared {} type",
+                definition.value_type.name()
+            );
+        }
+        if let Some(default) = &definition.default {
+            reject_nested_placeholder(name, default)?;
+        }
+        let value = if let Some(value) = environment(&definition.env)? {
+            definition.value_type.parse(name, value)?
+        } else if let Some(value) = &definition.default {
+            value.clone()
+        } else {
+            anyhow::bail!(
+                "build variable `{name}` requires environment variable `{}` or a default",
+                definition.env
+            );
         };
+        reject_nested_placeholder(name, &value)?;
         values.insert(name.clone(), value);
     }
     Ok(BuildVariables(values))
 }
 
-fn validate_variable_name(name: &str) -> anyhow::Result<()> {
+fn reject_nested_placeholder(name: &str, value: &Value) -> anyhow::Result<()> {
+    if value
+        .as_str()
+        .is_some_and(|value| value.contains(PLACEHOLDER_PREFIX))
+    {
+        anyhow::bail!("build variable `{name}` must not contain another build placeholder");
+    }
+    Ok(())
+}
+
+fn validate_name(name: &str) -> anyhow::Result<()> {
     let mut chars = name.chars();
-    let valid = chars
+    if !chars
         .next()
         .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
-        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric());
-    if !valid {
+        || !chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    {
         anyhow::bail!(
             "invalid build variable name `{name}`; use ASCII letters, digits, and underscores, starting with a letter or underscore"
         );
@@ -141,131 +176,45 @@ fn validate_variable_name(name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_environment_value(
-    name: &str,
-    value: String,
-    value_type: BuildVariableType,
-) -> anyhow::Result<BuildVariableValue> {
-    match value_type {
-        BuildVariableType::String => Ok(BuildVariableValue::String(value)),
-        BuildVariableType::Integer => value
-            .parse()
-            .map(BuildVariableValue::Integer)
-            .map_err(|_| anyhow::anyhow!("build variable `{name}` must be an integer")),
-        BuildVariableType::Boolean => value
-            .parse()
-            .map(BuildVariableValue::Boolean)
-            .map_err(|_| anyhow::anyhow!("build variable `{name}` must be `true` or `false`")),
-    }
-}
-
-fn parse_default_value(
-    name: &str,
-    value: &serde_json::Value,
-    value_type: BuildVariableType,
-) -> anyhow::Result<BuildVariableValue> {
-    let resolved = match value_type {
-        BuildVariableType::String => value
-            .as_str()
-            .map(|value| BuildVariableValue::String(value.to_owned())),
-        BuildVariableType::Integer => value.as_i64().map(BuildVariableValue::Integer),
-        BuildVariableType::Boolean => value.as_bool().map(BuildVariableValue::Boolean),
-    };
-    resolved.ok_or_else(|| {
-        anyhow::anyhow!(
-            "default for build variable `{name}` does not match its declared {} type",
-            match value_type {
-                BuildVariableType::String => "string",
-                BuildVariableType::Integer => "integer",
-                BuildVariableType::Boolean => "boolean",
-            }
-        )
-    })
-}
-
-/// Recursively expands Crossbow placeholders in JSON-like typed configuration data. An exact
-/// placeholder retains its declared integer or Boolean type.
-pub fn interpolate_json_build_variables(
-    value: &mut serde_json::Value,
-    variables: &BuildVariables,
-) -> anyhow::Result<()> {
+fn interpolate_json(value: &mut Value, variables: &BuildVariables) -> anyhow::Result<()> {
     match value {
-        serde_json::Value::Array(values) => {
+        Value::Array(values) => {
             for value in values {
-                interpolate_json_build_variables(value, variables)?;
+                interpolate_json(value, variables)?;
             }
         }
-        serde_json::Value::Object(values) => {
+        Value::Object(values) => {
             for value in values.values_mut() {
-                interpolate_json_build_variables(value, variables)?;
+                interpolate_json(value, variables)?;
             }
         }
-        serde_json::Value::String(template) => {
-            if let Some(resolved) = exact_build_variable(template, variables)? {
-                *value = resolved.as_json();
-            } else {
-                *template = interpolate_string(template, variables)?;
-            }
-        }
+        Value::String(template) => match exact_variable(template, variables)? {
+            Some(resolved) => *value = resolved.clone(),
+            None => *template = interpolate_string(template, variables)?,
+        },
         _ => {}
     }
     Ok(())
 }
 
-fn exact_placeholder(template: &str) -> Option<&str> {
-    template
-        .strip_prefix(PLACEHOLDER_PREFIX)?
-        .strip_suffix("}}")
-        .filter(|name| !name.contains("}}"))
-}
-
-/// Returns the typed value when the entire string is one Crossbow placeholder.
-pub fn exact_build_variable<'a>(
+pub(crate) fn exact_variable<'a>(
     template: &str,
     variables: &'a BuildVariables,
-) -> anyhow::Result<Option<&'a BuildVariableValue>> {
-    let Some(name) = exact_placeholder(template) else {
+) -> anyhow::Result<Option<&'a Value>> {
+    let Some(name) = template
+        .strip_prefix(PLACEHOLDER_PREFIX)
+        .and_then(|value| value.strip_suffix("}}"))
+        .filter(|name| !name.contains("}}"))
+    else {
         return Ok(None);
     };
-    validate_variable_name(name)?;
+    validate_name(name)?;
     variable(variables, name).map(Some)
 }
 
-/// Expands all Crossbow placeholders in a string while leaving Android `${...}` and Xcode
-/// `$(...)` build-setting syntax untouched.
-pub fn interpolate_build_variables(
+pub(crate) fn interpolate_string(
     template: &str,
     variables: &BuildVariables,
-) -> anyhow::Result<String> {
-    interpolate_string(template, variables)
-}
-
-/// Expands integer, Boolean, and XML-safe string variables before Android's typed XML parser.
-/// Strings requiring XML entities remain as placeholders until after parsing, avoiding a
-/// double-unescape limitation in the upstream manifest deserializer.
-pub fn interpolate_typed_build_variables(
-    template: &str,
-    variables: &BuildVariables,
-) -> anyhow::Result<String> {
-    interpolate_string_with(template, variables, |placeholder, value| match value {
-        BuildVariableValue::String(value)
-            if xml::escape::escape_str_attribute(value).as_ref() == value =>
-        {
-            value.clone()
-        }
-        BuildVariableValue::String(_) => placeholder.to_owned(),
-        BuildVariableValue::Integer(_) | BuildVariableValue::Boolean(_) => value.as_string(),
-    })
-}
-
-fn interpolate_string(template: &str, variables: &BuildVariables) -> anyhow::Result<String> {
-    interpolate_string_with(template, variables, |_, value| value.as_string())
-}
-
-fn interpolate_string_with(
-    template: &str,
-    variables: &BuildVariables,
-    mut replacement: impl FnMut(&str, &BuildVariableValue) -> String,
 ) -> anyhow::Result<String> {
     let mut output = String::with_capacity(template.len());
     let mut remaining = template;
@@ -276,24 +225,29 @@ fn interpolate_string_with(
             anyhow::bail!("unterminated Crossbow build variable placeholder");
         };
         let name = &placeholder[..end];
-        validate_variable_name(name)?;
-        let original = &remaining[start..start + PLACEHOLDER_PREFIX.len() + end + 2];
-        output.push_str(&replacement(original, variable(variables, name)?));
+        validate_name(name)?;
+        output.push_str(&display(variable(variables, name)?));
         remaining = &placeholder[end + 2..];
     }
     output.push_str(remaining);
     Ok(output)
 }
 
-fn variable<'a>(
-    variables: &'a BuildVariables,
-    name: &str,
-) -> anyhow::Result<&'a BuildVariableValue> {
+fn variable<'a>(variables: &'a BuildVariables, name: &str) -> anyhow::Result<&'a Value> {
     variables.get(name).ok_or_else(|| {
         anyhow::anyhow!(
             "build variable `{name}` is used but not declared in `package.metadata.build_variables`"
         )
     })
+}
+
+fn display(value: &Value) -> Cow<'_, str> {
+    match value {
+        Value::String(value) => Cow::Borrowed(value),
+        Value::Number(value) => Cow::Owned(value.to_string()),
+        Value::Bool(value) => Cow::Owned(value.to_string()),
+        _ => unreachable!("build variables are validated scalar values"),
+    }
 }
 
 #[cfg(test)]
@@ -310,59 +264,57 @@ mod tests {
     }
 
     #[test]
-    fn environment_wins_and_defaults_retain_types() {
+    fn environment_wins_while_defaults_keep_their_types() {
         let values = resolve_definitions(&definitions(), |name| {
-            Ok((name == "API_HOST").then(|| "api.example.com".to_owned()))
+            Ok((name == "API_HOST").then(|| "例.example".to_owned()))
         })
         .unwrap();
-        assert_eq!(
-            values.get("HOST"),
-            Some(&BuildVariableValue::String("api.example.com".into()))
-        );
-        assert_eq!(values.get("BUILD"), Some(&BuildVariableValue::Integer(7)));
-        assert_eq!(
-            values.get("ENABLED"),
-            Some(&BuildVariableValue::Boolean(false))
-        );
+        assert_eq!(values.get("HOST"), Some(&serde_json::json!("例.example")));
+        assert_eq!(values.get("BUILD"), Some(&serde_json::json!(7)));
+        assert_eq!(values.get("ENABLED"), Some(&serde_json::json!(false)));
+        assert!(!format!("{values:?}").contains("例.example"));
     }
 
     #[test]
-    fn expands_embedded_unicode_and_preserves_platform_placeholders() {
-        let values = resolve_definitions(&definitions(), |_| Ok(None)).unwrap();
-        let result = interpolate_string(
-            "https://{{crossbow.HOST}}/build/{{crossbow.BUILD}}/✓/${applicationId}/$(PRODUCT_NAME)",
-            &values,
-        )
+    fn empty_strings_override_defaults() {
+        let values = resolve_definitions(&definitions(), |name| {
+            Ok((name == "API_HOST").then(String::new))
+        })
         .unwrap();
+        assert_eq!(values.get("HOST"), Some(&serde_json::json!("")));
+    }
+
+    #[test]
+    fn interpolation_is_typed_scoped_and_platform_safe() {
+        let mut metadata = serde_json::json!({
+            "build_variables": {
+                "HOST": { "env": "API_HOST", "default": "localhost" },
+                "BUILD": { "env": "BUILD_NUMBER", "type": "integer", "default": 7 }
+            },
+            "app_name": "{{crossbow.HOST}}",
+            "android": { "manifest": {
+                "version_code": "{{crossbow.BUILD}}",
+                "application": { "label": "{{crossbow.HOST}}/${applicationId}/$(PRODUCT_NAME)" }
+            }}
+        });
+        resolve_metadata_build_variables(&mut metadata).unwrap();
+        assert_eq!(metadata["app_name"], "{{crossbow.HOST}}");
+        assert_eq!(metadata["android"]["manifest"]["version_code"], 7);
         assert_eq!(
-            result,
-            "https://localhost/build/7/✓/${applicationId}/$(PRODUCT_NAME)"
+            metadata["android"]["manifest"]["application"]["label"],
+            "localhost/${applicationId}/$(PRODUCT_NAME)"
         );
     }
 
     #[test]
-    fn exact_json_placeholders_become_typed_values() {
-        let values = resolve_definitions(&definitions(), |_| Ok(None)).unwrap();
-        let mut metadata = serde_json::json!({
-            "number": "{{crossbow.BUILD}}",
-            "enabled": "{{crossbow.ENABLED}}",
-            "label": "build-{{crossbow.BUILD}}"
-        });
-        interpolate_json_build_variables(&mut metadata, &values).unwrap();
-        assert_eq!(metadata["number"], 7);
-        assert_eq!(metadata["enabled"], false);
-        assert_eq!(metadata["label"], "build-7");
-    }
-
-    #[test]
-    fn rejects_missing_invalid_and_undeclared_variables() {
+    fn rejects_missing_malformed_undeclared_and_nested_values() {
         let mut missing = definitions();
         missing.get_mut("HOST").unwrap().default = None;
         assert!(
             resolve_definitions(&missing, |_| Ok(None))
                 .unwrap_err()
                 .to_string()
-                .contains("requires environment variable `API_HOST`")
+                .contains("requires environment variable")
         );
         assert!(
             interpolate_string("{{crossbow.SECRET}}", &BuildVariables::default())
@@ -376,16 +328,33 @@ mod tests {
                 .to_string()
                 .contains("unterminated")
         );
+
+        let nested: BuildVariableDefinitions = serde_json::from_value(serde_json::json!({
+            "BAD": { "env": "BAD", "default": "{{crossbow.OTHER}}" }
+        }))
+        .unwrap();
+        assert!(
+            resolve_definitions(&nested, |_| Ok(Some("valid".into())))
+                .unwrap_err()
+                .to_string()
+                .contains("must not contain")
+        );
     }
 
     #[test]
-    fn rejects_environment_and_default_type_mismatches() {
+    fn rejects_invalid_names_and_types() {
+        let invalid: BuildVariableDefinitions = serde_json::from_value(serde_json::json!({
+            "not-valid": { "env": "VALUE", "default": "value" }
+        }))
+        .unwrap();
+        assert!(resolve_definitions(&invalid, |_| Ok(None)).is_err());
+
         let integer: BuildVariableDefinitions = serde_json::from_value(serde_json::json!({
             "BUILD": { "env": "BUILD_NUMBER", "type": "integer" }
         }))
         .unwrap();
         assert!(
-            resolve_definitions(&integer, |_| Ok(Some("1.5".into())))
+            resolve_definitions(&integer, |_| Ok(Some(String::new())))
                 .unwrap_err()
                 .to_string()
                 .contains("must be an integer")
@@ -396,10 +365,10 @@ mod tests {
         }))
         .unwrap();
         assert!(
-            resolve_definitions(&boolean, |_| Ok(None))
+            resolve_definitions(&boolean, |_| Ok(Some("false".into())))
                 .unwrap_err()
                 .to_string()
-                .contains("does not match its declared boolean type")
+                .contains("declared boolean type")
         );
     }
 }

--- a/crossbundle/tools/src/types/common/mod.rs
+++ b/crossbundle/tools/src/types/common/mod.rs
@@ -1,9 +1,11 @@
+mod build_variables;
 mod config;
 mod profile;
 mod shell;
 mod target;
 mod version;
 
+pub use build_variables::*;
 pub use config::*;
 pub use profile::*;
 pub use shell::*;

--- a/crossbundle/tools/src/types/project.rs
+++ b/crossbundle/tools/src/types/project.rs
@@ -1,6 +1,9 @@
 use crossbow::Permission;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use super::{BuildVariables, resolve_metadata_build_variables};
 
@@ -54,11 +57,11 @@ impl GradleDependencyProject {
 }
 
 /// Typed `package.metadata` model shared by builds and project diagnostics.
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Clone, Deserialize, Serialize, Default)]
 pub struct CrossbowMetadata {
     /// Resolved allow-listed values used by platform configuration templates.
     #[serde(skip)]
-    pub build_variables: BuildVariables,
+    build_variables: BuildVariables,
     pub app_name: Option<String>,
     #[serde(default)]
     pub assets: Vec<PathBuf>,
@@ -73,7 +76,26 @@ pub struct CrossbowMetadata {
     pub apple: AppleConfig,
 }
 
+impl fmt::Debug for CrossbowMetadata {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut metadata = serde_json::to_value(self).map_err(|_| fmt::Error)?;
+        if !self.build_variables.is_empty() {
+            for pointer in ["/android/manifest", "/apple/info_plist"] {
+                if let Some(value) = metadata.pointer_mut(pointer) {
+                    *value = serde_json::Value::String("<redacted>".into());
+                }
+            }
+        }
+        metadata.fmt(formatter)
+    }
+}
+
 impl CrossbowMetadata {
+    /// Returns resolved values for platform-document interpolation.
+    pub fn build_variables(&self) -> &BuildVariables {
+        &self.build_variables
+    }
+
     #[cfg(feature = "android")]
     pub fn get_android_assets(&self) -> &[PathBuf] {
         if self.android.assets.is_empty() {
@@ -152,7 +174,7 @@ pub fn deserialize_crossbow_metadata(
         .get_mut("android")
         .and_then(|android| android.get_mut("manifest"))
     {
-        crate::types::normalize_android_manifest_json(manifest);
+        crate::types::normalize_android_booleans(manifest);
     }
     let mut resolved: CrossbowMetadata = serde_json::from_value(metadata)?;
     resolved.build_variables = build_variables;
@@ -199,19 +221,40 @@ mod android_config_tests {
                 "LABEL": {
                     "env": "CROSSBOW_TEST_UNSET_INLINE_ANDROID_LABEL",
                     "default": "Preview"
+                },
+                "ENABLED": {
+                    "env": "CROSSBOW_TEST_UNSET_INLINE_ANDROID_ENABLED",
+                    "type": "boolean",
+                    "default": true
                 }
             },
             "android": {
                 "manifest": {
                     "version_code": "{{crossbow.CODE}}",
-                    "application": { "label": "{{crossbow.LABEL}}" }
+                    "application": {
+                        "label": "{{crossbow.LABEL}}",
+                        "has_code": "{{crossbow.ENABLED}}",
+                        "activity": [{
+                            "name": ".MainActivity",
+                            "intent_filter": [{ "auto_verify": "{{crossbow.ENABLED}}" }]
+                        }]
+                    }
                 }
             }
         }))
         .unwrap();
+        assert!(!format!("{metadata:?}").contains("Preview"));
         let manifest = metadata.android.manifest.unwrap();
         assert_eq!(manifest.version_code, Some(73));
         assert_eq!(manifest.application.label.unwrap().to_string(), "Preview");
+        assert_eq!(
+            manifest.application.has_code,
+            Some(android_manifest::VarOrBool::Bool(true))
+        );
+        assert_eq!(
+            manifest.application.activity[0].intent_filter[0].auto_verify,
+            Some(true)
+        );
     }
 }
 
@@ -235,6 +278,7 @@ mod apple_build_variable_tests {
             }
         }))
         .unwrap();
+        assert!(!format!("{metadata:?}").contains("dev.crossbow.preview"));
         assert_eq!(
             metadata
                 .apple

--- a/crossbundle/tools/src/types/project.rs
+++ b/crossbundle/tools/src/types/project.rs
@@ -2,6 +2,8 @@ use crossbow::Permission;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+use super::{BuildVariables, resolve_metadata_build_variables};
+
 #[cfg(feature = "android")]
 use crate::types::{AndroidRuntime, AndroidTarget, android_manifest::AndroidManifest};
 #[cfg(feature = "apple")]
@@ -54,6 +56,9 @@ impl GradleDependencyProject {
 /// Typed `package.metadata` model shared by builds and project diagnostics.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct CrossbowMetadata {
+    /// Resolved allow-listed values used by platform configuration templates.
+    #[serde(skip)]
+    pub build_variables: BuildVariables,
     pub app_name: Option<String>,
     #[serde(default)]
     pub assets: Vec<PathBuf>,
@@ -123,11 +128,12 @@ pub struct AndroidConfig {
 }
 
 pub fn deserialize_crossbow_metadata(
-    metadata: serde_json::Value,
+    mut metadata: serde_json::Value,
 ) -> anyhow::Result<CrossbowMetadata> {
     if metadata.is_null() {
         return Ok(CrossbowMetadata::default());
     }
+    let build_variables = resolve_metadata_build_variables(&mut metadata)?;
     #[cfg(feature = "android")]
     if let Some(android) = metadata.get("android") {
         if android.get("rust_compiler").is_some() {
@@ -141,7 +147,9 @@ pub fn deserialize_crossbow_metadata(
             );
         }
     }
-    Ok(serde_json::from_value(metadata)?)
+    let mut resolved: CrossbowMetadata = serde_json::from_value(metadata)?;
+    resolved.build_variables = build_variables;
+    Ok(resolved)
 }
 
 #[cfg(all(test, feature = "android"))]
@@ -170,6 +178,65 @@ mod android_config_tests {
         let metadata = deserialize_crossbow_metadata(serde_json::Value::Null).unwrap();
         assert!(metadata.app_name.is_none());
         assert_eq!(metadata.android.runtime, AndroidRuntime::NativeActivity);
+    }
+
+    #[test]
+    fn resolves_inline_android_metadata_before_typed_deserialization() {
+        let metadata = deserialize_crossbow_metadata(serde_json::json!({
+            "build_variables": {
+                "CODE": {
+                    "env": "CROSSBOW_TEST_UNSET_INLINE_ANDROID_CODE",
+                    "type": "integer",
+                    "default": 73
+                },
+                "LABEL": {
+                    "env": "CROSSBOW_TEST_UNSET_INLINE_ANDROID_LABEL",
+                    "default": "Preview"
+                }
+            },
+            "android": {
+                "manifest": {
+                    "version_code": "{{crossbow.CODE}}",
+                    "application": { "label": "{{crossbow.LABEL}}" }
+                }
+            }
+        }))
+        .unwrap();
+        let manifest = metadata.android.manifest.unwrap();
+        assert_eq!(manifest.version_code, Some(73));
+        assert_eq!(manifest.application.label.unwrap().to_string(), "Preview");
+    }
+}
+
+#[cfg(all(test, feature = "apple"))]
+mod apple_build_variable_tests {
+    use super::*;
+
+    #[test]
+    fn resolves_inline_apple_metadata() {
+        let metadata = deserialize_crossbow_metadata(serde_json::json!({
+            "build_variables": {
+                "BUNDLE_ID": {
+                    "env": "CROSSBOW_TEST_UNSET_INLINE_APPLE_BUNDLE_ID",
+                    "default": "dev.crossbow.preview"
+                }
+            },
+            "apple": {
+                "info_plist": {
+                    "CFBundleIdentifier": "{{crossbow.BUNDLE_ID}}"
+                }
+            }
+        }))
+        .unwrap();
+        assert_eq!(
+            metadata
+                .apple
+                .info_plist
+                .unwrap()
+                .identification
+                .bundle_identifier,
+            "dev.crossbow.preview"
+        );
     }
 }
 

--- a/crossbundle/tools/src/types/project.rs
+++ b/crossbundle/tools/src/types/project.rs
@@ -147,6 +147,13 @@ pub fn deserialize_crossbow_metadata(
             );
         }
     }
+    #[cfg(feature = "android")]
+    if let Some(manifest) = metadata
+        .get_mut("android")
+        .and_then(|android| android.get_mut("manifest"))
+    {
+        crate::types::normalize_android_manifest_json(manifest);
+    }
     let mut resolved: CrossbowMetadata = serde_json::from_value(metadata)?;
     resolved.build_variables = build_variables;
     Ok(resolved)

--- a/docs/src/crossbow/configuration.md
+++ b/docs/src/crossbow/configuration.md
@@ -27,6 +27,14 @@ assets = ["assets"]
 # Path to icon with `.png` format that will be provided to generate mipmap resources
 icon = "path/to/icon.png"
 
+# Explicitly import build-time environment variables. Undeclared environment variables are never
+# available to configuration templates.
+[package.metadata.build_variables]
+API_HOST = { env = "API_HOST" }
+BUILD_NUMBER = { env = "CI_BUILD_NUMBER", type = "integer" }
+APP_CHANNEL = { env = "APP_CHANNEL", default = "development" }
+FEATURE_ENABLED = { env = "FEATURE_ENABLED", type = "boolean", default = false }
+
 [package.metadata.android]
 # Optional activity integration. The default is "native-activity"; use
 # "miniquad" for Macroquad projects built with the Gradle strategy.
@@ -87,6 +95,41 @@ release_build_targets = ["aarch64-apple-ios"]
 # Apple resources directory path relatively to project path.
 resources = ["res/apple"]
 ```
+
+### Build variables
+
+Build variables let the same checked-in configuration produce environment-specific Android and
+Apple bundles. Declare every imported value under `package.metadata.build_variables`, then use it
+as `{{crossbow.NAME}}` in inline metadata, an external `AndroidManifest.xml`, or an external
+`Info.plist`:
+
+```xml
+<!-- AndroidManifest.xml -->
+<meta-data
+    android:name="com.example.api_host"
+    android:value="https://{{crossbow.API_HOST}}/v1" />
+```
+
+```xml
+<!-- Info.plist -->
+<key>APIHost</key>
+<string>{{crossbow.API_HOST}}</string>
+```
+
+Crossbundle reads the named environment variable first and uses `default` only when it is absent.
+A missing value without a default stops the build with the declaration name. The default type is
+`string`; `type = "integer"` and `type = "boolean"` validate environment input and preserve the
+native type when the placeholder is the complete metadata or plist value. A placeholder embedded
+inside a larger string is formatted as text.
+
+Only allow-listed variables are readable. The syntax intentionally does not conflict with Android
+`${applicationId}` placeholders or Xcode `$(PRODUCT_BUNDLE_IDENTIFIER)` build settings. XML special
+characters and Unicode are escaped by the platform serializers, and both XML and binary plists are
+supported.
+
+> Build variables are public application configuration, not secrets. Values embedded in
+> `AndroidManifest.xml` or `Info.plist` can be inspected by anyone with the built application. Do
+> not use this feature for passwords, signing credentials, private keys, or API secrets.
 
 ### Сonfiguration through separate files
 

--- a/docs/src/crossbow/configuration.md
+++ b/docs/src/crossbow/configuration.md
@@ -5,7 +5,7 @@ Gradle 9.5.0, Java 17, and NDK 28.2. New Google Play submissions must target
 API 36 from August 31, 2026; see the official
 [target API requirements](https://developer.android.com/google/play/requirements/target-sdk).
 
-## Сonfiguration through metadata
+## Configuration through metadata
 
 The easiest way to configure a project is with metadata. Here's an example of `Cargo.toml`:
 
@@ -22,7 +22,7 @@ crossbow = "0.2.3"
 [package.metadata]
 # The user-friendly application name for your app. Displayed in the applications menu
 app_name = "Game"
-# Android assets directory path relatively to project path
+# Android assets directory path relative to the project path
 assets = ["assets"]
 # Path to icon with `.png` format that will be provided to generate mipmap resources
 icon = "path/to/icon.png"
@@ -70,9 +70,8 @@ meta_data = []
 # See https://developer.android.com/guide/topics/manifest/queries-element#provider
 [[package.metadata.android.manifest.queries.provider]]
 authorities = "org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker"
-# Note: The `name` attribute is normally not required for a queries provider, but is non-optional
-# as a workaround for aapt throwing errors about missing `android:name` attribute.
-# This will be made optional if/when cargo-apk migrates to aapt2.
+# The `android-manifest` model currently requires `name` even though Android queries providers
+# normally require only `authorities`.
 name = "org.khronos.openxr"
 
 # See https://developer.android.com/guide/topics/manifest/uses-feature-element
@@ -100,8 +99,8 @@ resources = ["res/apple"]
 
 Build variables let the same checked-in configuration produce environment-specific Android and
 Apple bundles. Declare every imported value under `package.metadata.build_variables`, then use it
-as `{{crossbow.NAME}}` in inline metadata, an external `AndroidManifest.xml`, or an external
-`Info.plist`:
+as `{{crossbow.NAME}}` in an inline platform document, an external `AndroidManifest.xml`, or an
+external `Info.plist`:
 
 ```xml
 <!-- AndroidManifest.xml -->
@@ -116,11 +115,12 @@ as `{{crossbow.NAME}}` in inline metadata, an external `AndroidManifest.xml`, or
 <string>{{crossbow.API_HOST}}</string>
 ```
 
-Crossbundle reads the named environment variable first and uses `default` only when it is absent.
-A missing value without a default stops the build with the declaration name. The default type is
-`string`; `type = "integer"` and `type = "boolean"` validate environment input and preserve the
-native type when the placeholder is the complete metadata or plist value. A placeholder embedded
-inside a larger string is formatted as text.
+Crossbundle reads the named environment variable first and uses `default` only when it is absent;
+an empty environment value therefore overrides the default. A missing value without a default
+stops the build with the declaration name. The default type is `string`; `type = "integer"` and
+`type = "boolean"` validate environment input and preserve the native type when the placeholder is
+the complete metadata or plist value. A placeholder embedded inside a larger string is formatted
+as text. Variable values cannot contain other build-variable placeholders.
 
 Only allow-listed variables are readable. The syntax intentionally does not conflict with Android
 `${applicationId}` placeholders or Xcode `$(PRODUCT_BUNDLE_IDENTIFIER)` build settings. XML special
@@ -131,9 +131,9 @@ supported.
 > `AndroidManifest.xml` or `Info.plist` can be inspected by anyone with the built application. Do
 > not use this feature for passwords, signing credentials, private keys, or API secrets.
 
-### Сonfiguration through separate files
+### Configuration through separate files
 
-But sometimes you need to configure something more complex. For such cases, a more suitable way is to use separate `AndroidManifest.xml` or/and `Info.plist` files.
+For more complex configuration, use separate `AndroidManifest.xml` and/or `Info.plist` files.
 
 To enable this feature, you just need to add this to your `Cargo.toml`:
 
@@ -145,7 +145,7 @@ manifest_path = "/path/to/file"
 info_plist_path = "/path/to/file"
 ```
 
-and then place `AndroidManifest.xml` or/and `Info.plist` near `Cargo.toml`
+and then place `AndroidManifest.xml` and/or `Info.plist` near `Cargo.toml`.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Closes #112.

## Summary

- add explicit, allow-listed `[package.metadata.build_variables]` declarations with environment names, defaults, and `string`/`integer`/`boolean` types
- expand neutral `{{crossbow.NAME}}` placeholders only inside inline or external `AndroidManifest.xml` and `Info.plist` documents
- preserve native integer and Boolean types for exact placeholders while formatting embedded values as text
- support Gradle APK, native APK, native AAB, XML plists, and binary plists without colliding with Android `${...}` or Xcode `$(...)` syntax
- reject missing, malformed, mistyped, undeclared, or nested values with actionable errors
- redact resolved values from debug output and keep them out of serialized resolver state and unrelated metadata/configuration
- document precedence, empty-value behavior, types, platform support, and the public-configuration security boundary

## Design

Android files use one XML event-stream interpolation pass before entering the typed manifest model. A small format-aware write normalization compensates for the current `android-manifest` nested escaping behavior without a second typed/JSON round trip. The XML dependency is enabled only with the Android feature.

Apple files are loaded as generic `plist::Value`, transformed recursively, and then converted to the existing typed `InfoPlist` model, giving XML and binary plists identical behavior.

Resolved variables are read-only after construction. Expansion is deliberately limited to platform documents, so values cannot flow into paths, plugin settings, `gradle.properties`, doctor reports, or dry-run plans.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p crossbundle-tools --all-features --lib -- --skip commands::android::native::aab::gen_minimal_unsigned_aab::tests::test_gen_minimal_unsigned_aab` (87 passed)
- `cargo test -p crossbundle --all-features --lib` (13 passed)
- `cargo test -p crossbundle-tools -p crossbundle --all-features --doc`
- strict Clippy for no features, Android-only, Apple-only, and all features/targets
- compile checks for Crossbundle tools and CLI with no features, Android-only, Apple-only, and all features

The skipped existing AAB unit requires an installed Android SDK build-tools directory on the host; CI covers the toolchain-backed Android, iOS, Windows, Linux, and Docker integration paths.
