### PR TITLE
Use canonical xml crate directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "serde",
  "serde_plain",
  "thiserror 2.0.20",
- "xml-rs 0.8.29",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "thiserror 2.0.20",
  "toml",
  "winapi",
- "xml-rs 1.0.0",
+ "xml",
  "zip",
 ]
 
@@ -3001,7 +3001,7 @@ checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
 dependencies = [
  "khronos_api",
  "log",
- "xml-rs 0.8.29",
+ "xml-rs",
 ]
 
 [[package]]
@@ -6608,15 +6608,6 @@ name = "xml-rs"
 version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
-
-[[package]]
-name = "xml-rs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
-dependencies = [
- "xml",
-]
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde = "1.0"
 serde_json = "1.0"
 semver = "1.0"
 toml = "1.1"
-xml-rs = "1.0"
+xml = "1.0"
 simctl = { version = "0.1.1", package = "creator-simctl" }
 tempfile = "3.27"
 termcolor = "1.4"

--- a/crossbundle/tools/Cargo.toml
+++ b/crossbundle/tools/Cargo.toml
@@ -70,7 +70,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 semver = { workspace = true }
 toml = { workspace = true }
-xml-rs = { workspace = true, optional = true }
+xml = { workspace = true, optional = true }
 
 dunce = { workspace = true }
 home = { workspace = true }
@@ -104,5 +104,5 @@ tempfile = { workspace = true }
 
 [features]
 default = ["android", "apple"]
-android = ["android-manifest", "android-tools", "dep:xml-rs"]
+android = ["android-manifest", "android-tools", "dep:xml"]
 apple = ["apple-bundle", "simctl", "crossbow/update-manifest"]


### PR DESCRIPTION
## Objective

- Depend directly on the canonical xml crate instead of the xml-rs compatibility wrapper.

## Solution

- Replace the workspace and Android feature dependencies with xml.
- Regenerate Cargo.lock to remove the xml-rs 1.0 wrapper package.

## Validation

- cargo fmt --all -- --check
- cargo check -p crossbundle-tools --no-default-features --features android
- Focused Android manifest reader and writer tests